### PR TITLE
fix: correct panics with invalid instructions

### DIFF
--- a/ristretto_classfile/src/error.rs
+++ b/ristretto_classfile/src/error.rs
@@ -52,6 +52,9 @@ pub enum Error {
     /// Invalid instruction
     #[error("Invalid instruction: {0}")]
     InvalidInstruction(u8),
+    /// Invalid instruction offset
+    #[error("Invalid instruction offset: {0}")]
+    InvalidInstructionOffset(u32),
     /// Invalid magic number when reading a class file
     #[error("Invalid magic number: {0}")]
     InvalidMagicNumber(u32),


### PR DESCRIPTION
This PR corrects several cases discovered with fuzz testing where invalid class file serialization/deserialization could panic:

https://github.com/theseus-rs/ristretto/actions/runs/10321814010/job/28575575642
```
#1317213	REDUCE cov: 1122 ft: 3171 corp: 748/123Kb lim: 4096 exec/s: 119746 rss: 184Mb L: 415/3085 MS: 3 ChangeBinInt-EraseBytes-PersAutoDict- DE: ".))\233"-
thread '<unnamed>' panicked at /Users/runner/work/ristretto/ristretto/ristretto_classfile/src/attributes/instruction_utils.rs:147:22:
byte instruction
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==3967== ERROR: libFuzzer: deadly signal
    #0 0x000101267d44 in __sanitizer_print_stack_trace+0x28 (librustc-nightly_rt.asan.dylib:arm64+0x5bd44)
    #1 0x0001005a0304 in fuzzer::PrintStackTrace()+0x30 (class_file_from_bytes:arm64+0x10020c304)
    #2 0x000100593298 in fuzzer::Fuzzer::CrashCallback()+0x54 (class_file_from_bytes:arm64+0x1001ff298)
    #3 0x00018feda580 in _sigtramp+0x34 (libsystem_platform.dylib:arm64+0x4580)
    #4 0x42480018fea9c1c  (<unknown module>)
    #5 0xff4600018fdb6a2c  (<unknown module>)
    #6 0xfb38800100610b9c  (<unknown module>)
    #7 0x00010065bdb0 in std::process::abort::h8c259f401fac238f+0x8 (class_file_from_bytes:arm64+0x1002c7db0)
    #8 0x00010059221c in libfuzzer_sys::initialize::_$u7b$$u7b$closure$u7d$$u7d$::h86471ca509cb7c27+0xb8 (class_file_from_bytes:arm64+0x1001fe21c)
    #9 0x0001006083e0 in std::panicking::rust_panic_with_hook::h0c14069677b57935+0x600 (class_file_from_bytes:arm64+0x1002743e0)
    #10 0x000100607cf8 in std::panicking::begin_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::h0b3d77b09f91f642+0x88 (class_file_from_bytes:arm64+0x100273cf8)
    #11 0x000100605634 in std::sys::backtrace::__rust_end_short_backtrace::ha362675fb2169e33+0x8 (class_file_from_bytes:arm64+0x100271634)
    #12 0x0001006079c0 in rust_begin_unwind+0x28 (class_file_from_bytes:arm64+0x1002739c0)
    #13 0x00010065dd64 in core::panicking::panic_fmt::h04f31ab3586560dc+0x2c (class_file_from_bytes:arm64+0x1002c9d64)
    #14 0x00010065dd34 in core::option::expect_failed::he1692a1e34bc8c38+0x44 (class_file_from_bytes:arm64+0x1002c9d34)
    #15 0x0001004d1434 in ristretto_classfile::attributes::instruction_utils::from_bytes::h13600cd6f2c7dc07+0x2d30 (class_file_from_bytes:arm64+0x10013d434)
    #16 0x00010049a7a4 in ristretto_classfile::attributes::attribute::Attribute::from_bytes::h9dead1f9cdcb4b91+0x64f8 (class_file_from_bytes:arm64+0x1001067a4)
    #17 0x0001005001cc in ristretto_classfile::class_file::ClassFile::from_bytes::h0bb3d579eba0023b+0x19d8 (class_file_from_bytes:arm64+0x10016c1cc)
    #18 0x0001003c2b90 in class_file_from_bytes::_::__libfuzzer_sys_run::h4060c8843f5812ca class_file_from_bytes.rs:11
    #19 0x0001003c21f4 in rust_fuzzer_test_input lib.rs:224
    #20 0x00010058ccdc in std::panicking::try::do_call::h7d0d25643a99c8b2+0xc4 (class_file_from_bytes:arm64+0x1001f8cdc)
    #21 0x000100592484 in __rust_try+0x18 (class_file_from_bytes:arm64+0x1001fe484)
    #22 0x000100591888 in LLVMFuzzerTestOneInput+0x16c (class_file_from_bytes:arm64+0x1001fd888)
    #23 0x000100594b5c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x150 (class_file_from_bytes:arm64+0x100200b5c)
    #24 0x0001005941ec in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*)+0x48 (class_file_from_bytes:arm64+0x1002001ec)
    #25 0x000100595bd8 in fuzzer::Fuzzer::MutateAndTestOne()+0x230 (class_file_from_bytes:arm64+0x100201bd8)
    #26 0x000100596a10 in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&)+0x398 (class_file_from_bytes:arm64+0x100202a10)
    #27 0x0001005b7be8 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1d74 (class_file_from_bytes:arm64+0x100223be8)
    #28 0x0001005c5460 in main+0x24 (class_file_from_bytes:arm64+0x100231460)
    #29 0x00018fb1f150  (<unknown module>)
    #30 0x15067ffffffffffc  (<unknown module>)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 5 ChangeBinInt-ShuffleBytes-CrossOver-ShuffleBytes-PersAutoDict- DE: ".))\233"-; base unit: be07dc4d6e417b0cc2512727439c0ae4b41588a6
0xca,0xfe,0xba,0xbe,0x32,0xe,0x0,0x2e,0x0,0x6,0x4,0x26,0x0,0x0,0x4,0x4,0x0,0x4,0x4,0x6,0x4,0x4,0xf5,0xf5,0x13,0x1,0x0,0x4,0x43,0x6f,0x64,0x65,0x1,0x0,0x4,0x1,0x2,0x0,0x0,0x0,0x0,0x0,0x0,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x13,0x1,0x0,0x4,0x0,0x0,0xca,0x0,0x26,0xe2,0x0,0x4,0x0,0x0,0x0,0x9,0x2e,0x29,0x29,0x9b,0x2e,0x0,0x6,0x4,0x26,0x0,0x0,0x4,0x4,0x0,0x4,0x4,0x6,0x4,0x4,0xf5,0xf5,0x13,0x1,0x0,0x4,0x43,0x6f,0x0,0x0,0x0,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x13,0x1,0x0,0x4,0x0,0x0,0x0,0x0,0x26,0xe2,0x0,0x4,0x0,0x0,0x0,0x9,0x0,0x6,0x4,0x26,0x0,0x0,0x4,0x4,0x0,0x4,0x4,0xf9,0xfb,0xfb,0xa,0xf5,0x13,0x1,0x1,0x43,0x4,0x65,0x6f,0x0,0x0,0x64,0x4,0x1,0x2,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x9,0x0,0x0,0x13,0x1,0x0,0x31,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x36,0x1,0x0,0x19,0x19,0x19,0x19,0x19,0x19,0x19,0x19,0x19,0x19,0x19,0x19,0x0,0x0,0x0,0x0,0x0,0x4e,0x0,0x2e,0x3a,0x0,0x6,0x4,0x26,0x0,
\312\376\272\2762\016\000.\000\006\004&\000\000\004\004\000\004\004\006\004\004\365\365\023\001\000\004Code\001\000\004\001\002\000\000\000\000\000\000\200\000\000\000\000\000\000\000\023\001\000\004\000\000\312\000&\342\000\004\000\000\000\011.))\233.\000\006\004&\000\000\004\004\000\004\004\006\004\004\365\365\023\001\000\004Co\000\000\000\200\000\000\000\000\000\000\000\023\001\000\004\000\000\000\000&\342\000\004\000\000\000\011\000\006\004&\000\000\004\004\000\004\004\371\373\373\012\365\023\001\001C\004eo\000\000d\004\001\002\000\000\000\000\000\000\000\011\000\000\023\001\0001\000\004\000\000\000\000\000\000\0006\001\000\031\031\031\031\031\031\031\031\031\031\031\031\000\000\000\000\000N\000.:\000\006\004&\000
artifact_prefix='/Users/runner/work/ristretto/ristretto/fuzz/artifacts/class_file_from_bytes/'; Test unit written to /Users/runner/work/ristretto/ristretto/fuzz/artifacts/class_file_from_bytes/crash-263e60c98932956331eed06260dac1b59572b0c4
Base64: yv66vjIOAC4ABgQmAAAEBAAEBAYEBPX1EwEABENvZGUBAAQBAgAAAAAAAIAAAAAAAAAAEwEABAAAygAm4gAEAAAACS4pKZsuAAYEJgAABAQABAQGBAT19RMBAARDbwAAAIAAAAAAAAAAEwEABAAAAAAm4gAEAAAACQAGBCYAAAQEAAQE+fv7CvUTAQFDBGVvAABkBAECAAAAAAAAAAkAABMBADEABAAAAAAAAAA2AQAZGRkZGRkZGRkZGRkAAAAAAE4ALjoABgQmAA==

────────────────────────────────────────────────────────────────────────────────

Failing input:

	fuzz/artifacts/class_file_from_bytes/crash-263e60c98932956331eed06260dac1b59572b0c4

Output of `std::fmt::Debug`:

	[202, 254, 186, 190, 50, 14, 0, 46, 0, 6, 4, 38, 0, 0, 4, 4, 0, 4, 4, 6, 4, 4, 245, 245, 19, 1, 0, 4, 67, 111, 100, 101, 1, 0, 4, 1, 2, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 19, 1, 0, 4, 0, 0, 202, 0, 38, 226, 0, 4, 0, 0, 0, 9, 46, 41, 41, 155, 46, 0, 6, 4, 38, 0, 0, 4, 4, 0, 4, 4, 6, 4, 4, 245, 245, 19, 1, 0, 4, 67, 111, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 19, 1, 0, 4, 0, 0, 0, 0, 38, 226, 0, 4, 0, 0, 0, 9, 0, 6, 4, 38, 0, 0, 4, 4, 0, 4, 4, 249, 251, 251, 10, 245, 19, 1, 1, 67, 4, 101, 111, 0, 0, 100, 4, 1, 2, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 19, 1, 0, 49, 0, 4, 0, 0, 0, 0, 0, 0, 0, 54, 1, 0, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 0, 0, 0, 0, 0, 78, 0, 46, 58, 0, 6, 4, 38, 0]

Reproduce with:

	cargo fuzz run class_file_from_bytes fuzz/artifacts/class_file_from_bytes/crash-263e60c98932956331eed06260dac1b59572b0c4

Minimize test case with:

	cargo fuzz tmin class_file_from_bytes fuzz/artifacts/class_file_from_bytes/crash-263e60c98932956331eed06260dac1b59572b0c4

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 77
```