### PR TITLE
fix: correct Java 8 string handling to encode Rust strings as UTF-16

### DIFF
--- a/ristretto_vm/src/local_variables.rs
+++ b/ristretto_vm/src/local_variables.rs
@@ -189,8 +189,10 @@ impl Display for LocalVariables {
                 continue;
             };
             let value = local.to_string();
-            if value.len() > 100 {
-                locals.push(format!("{}...", &value[..97]));
+            let chars: Vec<char> = value.chars().collect();
+            if chars.len() > 100 {
+                let value = chars.iter().take(97).collect::<String>();
+                locals.push(format!("{value}..."));
             } else {
                 locals.push(value);
             }

--- a/ristretto_vm/src/operand_stack.rs
+++ b/ristretto_vm/src/operand_stack.rs
@@ -152,8 +152,10 @@ impl Display for OperandStack {
                 let mut values = Vec::new();
                 for stack_entry in &stack {
                     let value = stack_entry.to_string();
-                    if value.len() > 100 {
-                        values.push(format!("{}...", &value[..97]));
+                    let chars: Vec<char> = value.chars().collect();
+                    if chars.len() > 100 {
+                        let value = chars.iter().take(97).collect::<String>();
+                        values.push(format!("{value}..."));
                     } else {
                         values.push(value);
                     }


### PR DESCRIPTION
* correct Java 8 string handling to encode Rust strings as UTF-16
* split strings on character instead of byte boundaries to support unicode