### PR TITLE
refactor: encapsulate OperandStack to Frame and remove unnecessary uses of Arc/RwLock

### DIFF
--- a/ristretto_vm/src/instruction/branch.rs
+++ b/ristretto_vm/src/instruction/branch.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_cond>
 #[inline]
-pub(crate) fn ifeq(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifeq(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_int()? == 0 {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -16,7 +16,7 @@ pub(crate) fn ifeq(stack: &OperandStack, address: u16) -> Result<ExecutionResult
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_cond>
 #[inline]
-pub(crate) fn ifne(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifne(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_int()? != 0 {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -25,7 +25,7 @@ pub(crate) fn ifne(stack: &OperandStack, address: u16) -> Result<ExecutionResult
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_cond>
 #[inline]
-pub(crate) fn iflt(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn iflt(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_int()? < 0 {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -34,7 +34,7 @@ pub(crate) fn iflt(stack: &OperandStack, address: u16) -> Result<ExecutionResult
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_cond>
 #[inline]
-pub(crate) fn ifge(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifge(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_int()? >= 0 {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -43,7 +43,7 @@ pub(crate) fn ifge(stack: &OperandStack, address: u16) -> Result<ExecutionResult
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_cond>
 #[inline]
-pub(crate) fn ifgt(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifgt(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_int()? > 0 {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -52,7 +52,7 @@ pub(crate) fn ifgt(stack: &OperandStack, address: u16) -> Result<ExecutionResult
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_cond>
 #[inline]
-pub(crate) fn ifle(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifle(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_int()? <= 0 {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -61,7 +61,7 @@ pub(crate) fn ifle(stack: &OperandStack, address: u16) -> Result<ExecutionResult
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_icmp_cond>
 #[inline]
-pub(crate) fn if_icmpeq(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_icmpeq(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     if value1 == value2 {
@@ -72,7 +72,7 @@ pub(crate) fn if_icmpeq(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_icmp_cond>
 #[inline]
-pub(crate) fn if_icmpne(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_icmpne(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     if value1 != value2 {
@@ -83,7 +83,7 @@ pub(crate) fn if_icmpne(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_icmp_cond>
 #[inline]
-pub(crate) fn if_icmplt(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_icmplt(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     if value1 < value2 {
@@ -94,7 +94,7 @@ pub(crate) fn if_icmplt(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_icmp_cond>
 #[inline]
-pub(crate) fn if_icmpge(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_icmpge(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     if value1 >= value2 {
@@ -105,7 +105,7 @@ pub(crate) fn if_icmpge(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_icmp_cond>
 #[inline]
-pub(crate) fn if_icmpgt(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_icmpgt(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     if value1 > value2 {
@@ -116,7 +116,7 @@ pub(crate) fn if_icmpgt(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_icmp_cond>
 #[inline]
-pub(crate) fn if_icmple(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_icmple(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     if value1 <= value2 {
@@ -127,7 +127,7 @@ pub(crate) fn if_icmple(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_acmp_cond>
 #[inline]
-pub(crate) fn if_acmpeq(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_acmpeq(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_object()?;
     let value1 = stack.pop_object()?;
     if value1 == value2 {
@@ -138,7 +138,7 @@ pub(crate) fn if_acmpeq(stack: &OperandStack, address: u16) -> Result<ExecutionR
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.if_acmp_cond>
 #[inline]
-pub(crate) fn if_acmpne(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn if_acmpne(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let value2 = stack.pop_object()?;
     let value1 = stack.pop_object()?;
     if value1 != value2 {
@@ -163,7 +163,7 @@ pub(crate) fn goto_w(address: i32) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.jsr>
 #[inline]
-pub(crate) fn jsr(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn jsr(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     let address = i32::from(address);
     stack.push_int(address)?;
     Ok(ContinueAtPosition(usize::try_from(address)?))
@@ -172,7 +172,7 @@ pub(crate) fn jsr(stack: &OperandStack, address: u16) -> Result<ExecutionResult>
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.jsr_w>
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.wide>
 #[inline]
-pub(crate) fn jsr_w(stack: &OperandStack, address: i32) -> Result<ExecutionResult> {
+pub(crate) fn jsr_w(stack: &mut OperandStack, address: i32) -> Result<ExecutionResult> {
     stack.push_int(address)?;
     Ok(ContinueAtPosition(usize::try_from(address)?))
 }
@@ -196,7 +196,7 @@ pub(crate) fn ret_w(locals: &LocalVariables, index: u16) -> Result<ExecutionResu
 #[expect(clippy::ptr_arg)]
 #[inline]
 pub(crate) fn tableswitch(
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     program_counter: usize,
     default: i32,
     low: i32,
@@ -216,7 +216,7 @@ pub(crate) fn tableswitch(
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lookupswitch>
 #[inline]
 pub(crate) fn lookupswitch(
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     program_counter: usize,
     default: i32,
     pairs: &IndexMap<i32, i32>,
@@ -238,7 +238,7 @@ pub(crate) fn r#return() -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ifnull>
 #[inline]
-pub(crate) fn ifnull(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifnull(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_object()?.is_none() {
         return Ok(ContinueAtPosition(usize::from(address)));
     }
@@ -247,7 +247,7 @@ pub(crate) fn ifnull(stack: &OperandStack, address: u16) -> Result<ExecutionResu
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ifnonnull>
 #[inline]
-pub(crate) fn ifnonnull(stack: &OperandStack, address: u16) -> Result<ExecutionResult> {
+pub(crate) fn ifnonnull(stack: &mut OperandStack, address: u16) -> Result<ExecutionResult> {
     if stack.pop_object()?.is_some() {
         return Ok(ContinueAtPosition(usize::from(address)));
     }

--- a/ristretto_vm/src/instruction/byte.rs
+++ b/ristretto_vm/src/instruction/byte.rs
@@ -8,7 +8,7 @@ use ristretto_classloader::Reference;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.baload>
 #[inline]
-pub(crate) fn baload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn baload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -30,7 +30,7 @@ pub(crate) fn baload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.bastore>
 #[inline]
-pub(crate) fn bastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn bastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {

--- a/ristretto_vm/src/instruction/char.rs
+++ b/ristretto_vm/src/instruction/char.rs
@@ -8,7 +8,7 @@ use ristretto_classloader::Reference;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.caload>
 #[inline]
-pub(crate) fn caload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn caload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -30,7 +30,7 @@ pub(crate) fn caload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.castore>
 #[inline]
-pub(crate) fn castore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn castore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {

--- a/ristretto_vm/src/instruction/convert.rs
+++ b/ristretto_vm/src/instruction/convert.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.i2l>
 #[inline]
-pub(crate) fn i2l(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn i2l(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     stack.push_long(i64::from(value))?;
     Ok(Continue)
@@ -13,7 +13,7 @@ pub(crate) fn i2l(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.i2f>
 #[inline]
-pub(crate) fn i2f(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn i2f(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     #[expect(clippy::cast_precision_loss)]
     stack.push_float(value as f32)?;
@@ -22,7 +22,7 @@ pub(crate) fn i2f(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.i2d>
 #[inline]
-pub(crate) fn i2d(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn i2d(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     stack.push_double(f64::from(value))?;
     Ok(Continue)
@@ -30,7 +30,7 @@ pub(crate) fn i2d(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.l2i>
 #[inline]
-pub(crate) fn l2i(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn l2i(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     #[expect(clippy::cast_possible_truncation)]
     stack.push_int(value as i32)?;
@@ -39,7 +39,7 @@ pub(crate) fn l2i(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.l2f>
 #[inline]
-pub(crate) fn l2f(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn l2f(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     #[expect(clippy::cast_precision_loss)]
     stack.push_float(value as f32)?;
@@ -48,7 +48,7 @@ pub(crate) fn l2f(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.l2d>
 #[inline]
-pub(crate) fn l2d(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn l2d(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     #[expect(clippy::cast_precision_loss)]
     stack.push_double(value as f64)?;
@@ -57,7 +57,7 @@ pub(crate) fn l2d(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.f2i>
 #[inline]
-pub(crate) fn f2i(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn f2i(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     #[expect(clippy::cast_possible_truncation)]
     stack.push_int(value as i32)?;
@@ -66,7 +66,7 @@ pub(crate) fn f2i(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.f2l>
 #[inline]
-pub(crate) fn f2l(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn f2l(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     #[expect(clippy::cast_possible_truncation)]
     stack.push_long(value as i64)?;
@@ -75,7 +75,7 @@ pub(crate) fn f2l(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.f2d>
 #[inline]
-pub(crate) fn f2d(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn f2d(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     stack.push_double(f64::from(value))?;
     Ok(Continue)
@@ -83,7 +83,7 @@ pub(crate) fn f2d(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.d2i>
 #[inline]
-pub(crate) fn d2i(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn d2i(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     #[expect(clippy::cast_possible_truncation)]
     stack.push_int(value as i32)?;
@@ -92,7 +92,7 @@ pub(crate) fn d2i(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.d2l>
 #[inline]
-pub(crate) fn d2l(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn d2l(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     #[expect(clippy::cast_possible_truncation)]
     stack.push_long(value as i64)?;
@@ -101,7 +101,7 @@ pub(crate) fn d2l(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.d2f>
 #[inline]
-pub(crate) fn d2f(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn d2f(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     #[expect(clippy::cast_possible_truncation)]
     stack.push_float(value as f32)?;
@@ -110,7 +110,7 @@ pub(crate) fn d2f(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.i2b>
 #[inline]
-pub(crate) fn i2b(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn i2b(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     #[expect(clippy::cast_possible_truncation)]
     let byte = value as i8;
@@ -120,7 +120,7 @@ pub(crate) fn i2b(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.i2c>
 #[inline]
-pub(crate) fn i2c(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn i2c(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     #[expect(clippy::cast_possible_truncation)]
     #[expect(clippy::cast_sign_loss)]
@@ -131,7 +131,7 @@ pub(crate) fn i2c(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.i2s>
 #[inline]
-pub(crate) fn i2s(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn i2s(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     #[expect(clippy::cast_possible_truncation)]
     let short = value as i16;

--- a/ristretto_vm/src/instruction/double.rs
+++ b/ristretto_vm/src/instruction/double.rs
@@ -10,14 +10,14 @@ use ristretto_classloader::Reference;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dconst_d>
 #[inline]
-pub(crate) fn dconst_0(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dconst_0(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_double(0f64)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dconst_d>
 #[inline]
-pub(crate) fn dconst_1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dconst_1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_double(1f64)?;
     Ok(Continue)
 }
@@ -26,7 +26,7 @@ pub(crate) fn dconst_1(stack: &OperandStack) -> Result<ExecutionResult> {
 #[inline]
 pub(crate) fn dload(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = locals.get_double(usize::from(index))?;
@@ -39,7 +39,7 @@ pub(crate) fn dload(
 #[inline]
 pub(crate) fn dload_w(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = locals.get_double(usize::from(index))?;
@@ -49,7 +49,10 @@ pub(crate) fn dload_w(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dload_n>
 #[inline]
-pub(crate) fn dload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dload_0(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_double(0)?;
     stack.push_double(value)?;
     Ok(Continue)
@@ -57,7 +60,10 @@ pub(crate) fn dload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dload_n>
 #[inline]
-pub(crate) fn dload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dload_1(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_double(1)?;
     stack.push_double(value)?;
     Ok(Continue)
@@ -65,7 +71,10 @@ pub(crate) fn dload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dload_n>
 #[inline]
-pub(crate) fn dload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dload_2(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_double(2)?;
     stack.push_double(value)?;
     Ok(Continue)
@@ -73,7 +82,10 @@ pub(crate) fn dload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dload_n>
 #[inline]
-pub(crate) fn dload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dload_3(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_double(3)?;
     stack.push_double(value)?;
     Ok(Continue)
@@ -83,7 +95,7 @@ pub(crate) fn dload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 #[inline]
 pub(crate) fn dstore(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
@@ -96,7 +108,7 @@ pub(crate) fn dstore(
 #[inline]
 pub(crate) fn dstore_w(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
@@ -108,7 +120,7 @@ pub(crate) fn dstore_w(
 #[inline]
 pub(crate) fn dstore_0(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     locals.set_double(0, value)?;
@@ -119,7 +131,7 @@ pub(crate) fn dstore_0(
 #[inline]
 pub(crate) fn dstore_1(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     locals.set_double(1, value)?;
@@ -130,7 +142,7 @@ pub(crate) fn dstore_1(
 #[inline]
 pub(crate) fn dstore_2(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     locals.set_double(2, value)?;
@@ -141,7 +153,7 @@ pub(crate) fn dstore_2(
 #[inline]
 pub(crate) fn dstore_3(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     locals.set_double(3, value)?;
@@ -150,7 +162,7 @@ pub(crate) fn dstore_3(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.daload>
 #[inline]
-pub(crate) fn daload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn daload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -172,7 +184,7 @@ pub(crate) fn daload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dastore>
 #[inline]
-pub(crate) fn dastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {
@@ -195,7 +207,7 @@ pub(crate) fn dastore(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dadd>
 #[inline]
-pub(crate) fn dadd(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dadd(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
     stack.push_double(value1 + value2)?;
@@ -204,7 +216,7 @@ pub(crate) fn dadd(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dsub>
 #[inline]
-pub(crate) fn dsub(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dsub(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
     stack.push_double(value1 - value2)?;
@@ -213,7 +225,7 @@ pub(crate) fn dsub(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dmul>
 #[inline]
-pub(crate) fn dmul(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dmul(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
     stack.push_double(value1 * value2)?;
@@ -222,7 +234,7 @@ pub(crate) fn dmul(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ddiv>
 #[inline]
-pub(crate) fn ddiv(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ddiv(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
 
@@ -236,7 +248,7 @@ pub(crate) fn ddiv(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.drem>
 #[inline]
-pub(crate) fn drem(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn drem(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
 
@@ -250,7 +262,7 @@ pub(crate) fn drem(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dneg>
 #[inline]
-pub(crate) fn dneg(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dneg(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     stack.push_double(-value)?;
     Ok(Continue)
@@ -258,7 +270,7 @@ pub(crate) fn dneg(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dcmpl>
 #[inline]
-pub(crate) fn dcmpl(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dcmpl(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
     let cmp = if f64::is_nan(value1) || f64::is_nan(value2) {
@@ -276,7 +288,7 @@ pub(crate) fn dcmpl(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dcmpg>
 #[inline]
-pub(crate) fn dcmpg(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dcmpg(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_double()?;
     let value1 = stack.pop_double()?;
     let cmp = if f64::is_nan(value1) || f64::is_nan(value2) || value1 > value2 {
@@ -292,7 +304,7 @@ pub(crate) fn dcmpg(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dreturn>
 #[inline]
-pub(crate) fn dreturn(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dreturn(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_double()?;
     Ok(Return(Some(Value::Double(value))))
 }

--- a/ristretto_vm/src/instruction/float.rs
+++ b/ristretto_vm/src/instruction/float.rs
@@ -10,21 +10,21 @@ use ristretto_classloader::Reference;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fconst_f>
 #[inline]
-pub(crate) fn fconst_0(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fconst_0(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_float(0f32)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fconst_f>
 #[inline]
-pub(crate) fn fconst_1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fconst_1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_float(1f32)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fconst_f>
 #[inline]
-pub(crate) fn fconst_2(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fconst_2(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_float(2f32)?;
     Ok(Continue)
 }
@@ -33,7 +33,7 @@ pub(crate) fn fconst_2(stack: &OperandStack) -> Result<ExecutionResult> {
 #[inline]
 pub(crate) fn fload(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = locals.get_float(usize::from(index))?;
@@ -46,7 +46,7 @@ pub(crate) fn fload(
 #[inline]
 pub(crate) fn fload_w(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = locals.get_float(usize::from(index))?;
@@ -56,7 +56,10 @@ pub(crate) fn fload_w(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fload_n>
 #[inline]
-pub(crate) fn fload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fload_0(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_float(0)?;
     stack.push_float(value)?;
     Ok(Continue)
@@ -64,7 +67,10 @@ pub(crate) fn fload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fload_n>
 #[inline]
-pub(crate) fn fload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fload_1(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_float(1)?;
     stack.push_float(value)?;
     Ok(Continue)
@@ -72,7 +78,10 @@ pub(crate) fn fload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fload_n>
 #[inline]
-pub(crate) fn fload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fload_2(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_float(2)?;
     stack.push_float(value)?;
     Ok(Continue)
@@ -80,7 +89,10 @@ pub(crate) fn fload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fload_n>
 #[inline]
-pub(crate) fn fload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fload_3(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_float(3)?;
     stack.push_float(value)?;
     Ok(Continue)
@@ -90,7 +102,7 @@ pub(crate) fn fload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 #[inline]
 pub(crate) fn fstore(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
@@ -103,7 +115,7 @@ pub(crate) fn fstore(
 #[inline]
 pub(crate) fn fstore_w(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
@@ -115,7 +127,7 @@ pub(crate) fn fstore_w(
 #[inline]
 pub(crate) fn fstore_0(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     locals.set_float(0, value)?;
@@ -126,7 +138,7 @@ pub(crate) fn fstore_0(
 #[inline]
 pub(crate) fn fstore_1(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     locals.set_float(1, value)?;
@@ -137,7 +149,7 @@ pub(crate) fn fstore_1(
 #[inline]
 pub(crate) fn fstore_2(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     locals.set_float(2, value)?;
@@ -148,7 +160,7 @@ pub(crate) fn fstore_2(
 #[inline]
 pub(crate) fn fstore_3(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     locals.set_float(3, value)?;
@@ -157,7 +169,7 @@ pub(crate) fn fstore_3(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.faload>
 #[inline]
-pub(crate) fn faload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn faload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -179,7 +191,7 @@ pub(crate) fn faload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fastore>
 #[inline]
-pub(crate) fn fastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {
@@ -202,7 +214,7 @@ pub(crate) fn fastore(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fadd>
 #[inline]
-pub(crate) fn fadd(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fadd(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
     stack.push_float(value1 + value2)?;
@@ -211,7 +223,7 @@ pub(crate) fn fadd(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fsub>
 #[inline]
-pub(crate) fn fsub(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fsub(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
     stack.push_float(value1 - value2)?;
@@ -220,7 +232,7 @@ pub(crate) fn fsub(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fmul>
 #[inline]
-pub(crate) fn fmul(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fmul(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
     stack.push_float(value1 * value2)?;
@@ -229,7 +241,7 @@ pub(crate) fn fmul(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fdiv>
 #[inline]
-pub(crate) fn fdiv(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fdiv(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
 
@@ -243,7 +255,7 @@ pub(crate) fn fdiv(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.frem>
 #[inline]
-pub(crate) fn frem(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn frem(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
 
@@ -257,7 +269,7 @@ pub(crate) fn frem(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fneg>
 #[inline]
-pub(crate) fn fneg(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fneg(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     stack.push_float(-value)?;
     Ok(Continue)
@@ -265,7 +277,7 @@ pub(crate) fn fneg(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fcmpl>
 #[inline]
-pub(crate) fn fcmpl(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fcmpl(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
     let cmp = if f32::is_nan(value1) || f32::is_nan(value2) {
@@ -283,7 +295,7 @@ pub(crate) fn fcmpl(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.fcmpg>
 #[inline]
-pub(crate) fn fcmpg(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn fcmpg(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_float()?;
     let value1 = stack.pop_float()?;
     let cmp = if f32::is_nan(value1) || f32::is_nan(value2) || value1 > value2 {
@@ -299,7 +311,7 @@ pub(crate) fn fcmpg(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.freturn>
 #[inline]
-pub(crate) fn freturn(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn freturn(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_float()?;
     Ok(Return(Some(Value::Float(value))))
 }

--- a/ristretto_vm/src/instruction/integer.rs
+++ b/ristretto_vm/src/instruction/integer.rs
@@ -10,49 +10,49 @@ use ristretto_classloader::Reference;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_m1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_m1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(-1)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_0(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_0(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(0)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(1)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_2(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_2(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(2)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_3(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_3(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(3)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_4(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_4(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(4)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iconst_i>
 #[inline]
-pub(crate) fn iconst_5(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iconst_5(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_int(5)?;
     Ok(Continue)
 }
@@ -61,7 +61,7 @@ pub(crate) fn iconst_5(stack: &OperandStack) -> Result<ExecutionResult> {
 #[inline]
 pub(crate) fn iload(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = locals.get_int(usize::from(index))?;
@@ -74,7 +74,7 @@ pub(crate) fn iload(
 #[inline]
 pub(crate) fn iload_w(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = locals.get_int(usize::from(index))?;
@@ -84,7 +84,10 @@ pub(crate) fn iload_w(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iload_n>
 #[inline]
-pub(crate) fn iload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iload_0(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_int(0)?;
     stack.push_int(value)?;
     Ok(Continue)
@@ -92,7 +95,10 @@ pub(crate) fn iload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iload_n>
 #[inline]
-pub(crate) fn iload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iload_1(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_int(1)?;
     stack.push_int(value)?;
     Ok(Continue)
@@ -100,7 +106,10 @@ pub(crate) fn iload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iload_n>
 #[inline]
-pub(crate) fn iload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iload_2(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_int(2)?;
     stack.push_int(value)?;
     Ok(Continue)
@@ -108,7 +117,10 @@ pub(crate) fn iload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iload_n>
 #[inline]
-pub(crate) fn iload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iload_3(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_int(3)?;
     stack.push_int(value)?;
     Ok(Continue)
@@ -118,7 +130,7 @@ pub(crate) fn iload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 #[inline]
 pub(crate) fn istore(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
@@ -131,7 +143,7 @@ pub(crate) fn istore(
 #[inline]
 pub(crate) fn istore_w(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
@@ -143,7 +155,7 @@ pub(crate) fn istore_w(
 #[inline]
 pub(crate) fn istore_0(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     locals.set_int(0, value)?;
@@ -154,7 +166,7 @@ pub(crate) fn istore_0(
 #[inline]
 pub(crate) fn istore_1(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     locals.set_int(1, value)?;
@@ -165,7 +177,7 @@ pub(crate) fn istore_1(
 #[inline]
 pub(crate) fn istore_2(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     locals.set_int(2, value)?;
@@ -176,7 +188,7 @@ pub(crate) fn istore_2(
 #[inline]
 pub(crate) fn istore_3(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     locals.set_int(3, value)?;
@@ -185,7 +197,7 @@ pub(crate) fn istore_3(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iaload>
 #[inline]
-pub(crate) fn iaload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iaload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -207,7 +219,7 @@ pub(crate) fn iaload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iastore>
 #[inline]
-pub(crate) fn iastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {
@@ -230,7 +242,7 @@ pub(crate) fn iastore(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iadd>
 #[inline]
-pub(crate) fn iadd(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iadd(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(i32::wrapping_add(value1, value2))?;
@@ -239,7 +251,7 @@ pub(crate) fn iadd(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.isub>
 #[inline]
-pub(crate) fn isub(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn isub(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(i32::wrapping_sub(value1, value2))?;
@@ -248,7 +260,7 @@ pub(crate) fn isub(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.imul>
 #[inline]
-pub(crate) fn imul(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn imul(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(i32::wrapping_mul(value1, value2))?;
@@ -257,7 +269,7 @@ pub(crate) fn imul(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.idiv>
 #[inline]
-pub(crate) fn idiv(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn idiv(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(
@@ -270,7 +282,7 @@ pub(crate) fn idiv(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.irem>
 #[inline]
-pub(crate) fn irem(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn irem(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(
@@ -283,7 +295,7 @@ pub(crate) fn irem(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ineg>
 #[inline]
-pub(crate) fn ineg(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ineg(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     stack.push_int(value.wrapping_neg())?;
     Ok(Continue)
@@ -291,7 +303,7 @@ pub(crate) fn ineg(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ishl>
 #[inline]
-pub(crate) fn ishl(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ishl(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(value1 << (value2 & 0x1f))?;
@@ -300,7 +312,7 @@ pub(crate) fn ishl(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ishr>
 #[inline]
-pub(crate) fn ishr(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ishr(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(value1 >> (value2 & 0x1f))?;
@@ -309,7 +321,7 @@ pub(crate) fn ishr(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iushr>
 #[inline]
-pub(crate) fn iushr(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iushr(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     let result = if value1 > 0 {
@@ -328,7 +340,7 @@ pub(crate) fn iushr(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.iand>
 #[inline]
-pub(crate) fn iand(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn iand(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(value1 & value2)?;
@@ -337,7 +349,7 @@ pub(crate) fn iand(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ior>
 #[inline]
-pub(crate) fn ior(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ior(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(value1 | value2)?;
@@ -346,7 +358,7 @@ pub(crate) fn ior(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ixor>
 #[inline]
-pub(crate) fn ixor(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ixor(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_int()?;
     stack.push_int(value1 ^ value2)?;
@@ -382,7 +394,7 @@ pub(crate) fn iinc_w(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ireturn>
 #[inline]
-pub(crate) fn ireturn(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ireturn(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     Ok(Return(Some(Value::Int(value))))
 }

--- a/ristretto_vm/src/instruction/long.rs
+++ b/ristretto_vm/src/instruction/long.rs
@@ -11,14 +11,14 @@ use std::cmp::Ordering;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lconst_l>
 #[inline]
-pub(crate) fn lconst_0(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lconst_0(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_long(0)?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lconst_l>
 #[inline]
-pub(crate) fn lconst_1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lconst_1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_long(1)?;
     Ok(Continue)
 }
@@ -27,7 +27,7 @@ pub(crate) fn lconst_1(stack: &OperandStack) -> Result<ExecutionResult> {
 #[inline]
 pub(crate) fn lload(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = locals.get_long(usize::from(index))?;
@@ -40,7 +40,7 @@ pub(crate) fn lload(
 #[inline]
 pub(crate) fn lload_w(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = locals.get_long(usize::from(index))?;
@@ -50,7 +50,10 @@ pub(crate) fn lload_w(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lload_n>
 #[inline]
-pub(crate) fn lload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lload_0(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_long(0)?;
     stack.push_long(value)?;
     Ok(Continue)
@@ -58,7 +61,10 @@ pub(crate) fn lload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lload_n>
 #[inline]
-pub(crate) fn lload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lload_1(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_long(1)?;
     stack.push_long(value)?;
     Ok(Continue)
@@ -66,7 +72,10 @@ pub(crate) fn lload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lload_n>
 #[inline]
-pub(crate) fn lload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lload_2(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_long(2)?;
     stack.push_long(value)?;
     Ok(Continue)
@@ -74,7 +83,10 @@ pub(crate) fn lload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lload_n>
 #[inline]
-pub(crate) fn lload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lload_3(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let value = locals.get_long(3)?;
     stack.push_long(value)?;
     Ok(Continue)
@@ -84,7 +96,7 @@ pub(crate) fn lload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 #[inline]
 pub(crate) fn lstore(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
@@ -97,7 +109,7 @@ pub(crate) fn lstore(
 #[inline]
 pub(crate) fn lstore_w(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
@@ -109,7 +121,7 @@ pub(crate) fn lstore_w(
 #[inline]
 pub(crate) fn lstore_0(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     locals.set_long(0, value)?;
@@ -120,7 +132,7 @@ pub(crate) fn lstore_0(
 #[inline]
 pub(crate) fn lstore_1(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     locals.set_long(1, value)?;
@@ -131,7 +143,7 @@ pub(crate) fn lstore_1(
 #[inline]
 pub(crate) fn lstore_2(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     locals.set_long(2, value)?;
@@ -142,7 +154,7 @@ pub(crate) fn lstore_2(
 #[inline]
 pub(crate) fn lstore_3(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     locals.set_long(3, value)?;
@@ -151,7 +163,7 @@ pub(crate) fn lstore_3(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.laload>
 #[inline]
-pub(crate) fn laload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn laload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -173,7 +185,7 @@ pub(crate) fn laload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lastore>
 #[inline]
-pub(crate) fn lastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {
@@ -196,7 +208,7 @@ pub(crate) fn lastore(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ladd>
 #[inline]
-pub(crate) fn ladd(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ladd(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(i64::wrapping_add(value1, value2))?;
@@ -205,7 +217,7 @@ pub(crate) fn ladd(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lsub>
 #[inline]
-pub(crate) fn lsub(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lsub(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(i64::wrapping_sub(value1, value2))?;
@@ -214,7 +226,7 @@ pub(crate) fn lsub(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lmul>
 #[inline]
-pub(crate) fn lmul(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lmul(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(i64::wrapping_mul(value1, value2))?;
@@ -223,7 +235,7 @@ pub(crate) fn lmul(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.ldiv>
 #[inline]
-pub(crate) fn ldiv(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn ldiv(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(
@@ -236,7 +248,7 @@ pub(crate) fn ldiv(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lrem>
 #[inline]
-pub(crate) fn lrem(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lrem(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(
@@ -249,7 +261,7 @@ pub(crate) fn lrem(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lneg>
 #[inline]
-pub(crate) fn lneg(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lneg(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     stack.push_long(value.wrapping_neg())?;
     Ok(Continue)
@@ -257,7 +269,7 @@ pub(crate) fn lneg(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lshl>
 #[inline]
-pub(crate) fn lshl(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lshl(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_long()?;
     stack.push_long(value1 << (value2 & 0x3f))?;
@@ -266,7 +278,7 @@ pub(crate) fn lshl(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lshr>
 #[inline]
-pub(crate) fn lshr(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lshr(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_long()?;
     stack.push_long(value1 >> (value2 & 0x3f))?;
@@ -275,7 +287,7 @@ pub(crate) fn lshr(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lushr>
 #[inline]
-pub(crate) fn lushr(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lushr(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_int()?;
     let value1 = stack.pop_long()?;
     let result = if value1 > 0 {
@@ -294,7 +306,7 @@ pub(crate) fn lushr(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.land>
 #[inline]
-pub(crate) fn land(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn land(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(value1 & value2)?;
@@ -303,7 +315,7 @@ pub(crate) fn land(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lor>
 #[inline]
-pub(crate) fn lor(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lor(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(value1 | value2)?;
@@ -312,7 +324,7 @@ pub(crate) fn lor(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lxor>
 #[inline]
-pub(crate) fn lxor(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lxor(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     stack.push_long(value1 ^ value2)?;
@@ -321,7 +333,7 @@ pub(crate) fn lxor(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lcmp>
 #[inline]
-pub(crate) fn lcmp(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lcmp(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value2 = stack.pop_long()?;
     let value1 = stack.pop_long()?;
     let cmp = match value1.cmp(&value2) {
@@ -335,7 +347,7 @@ pub(crate) fn lcmp(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.lreturn>
 #[inline]
-pub(crate) fn lreturn(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn lreturn(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_long()?;
     Ok(Return(Some(Value::Long(value))))
 }

--- a/ristretto_vm/src/instruction/monitor.rs
+++ b/ristretto_vm/src/instruction/monitor.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.monitorenter>
 #[inline]
-pub(crate) fn monitorenter(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn monitorenter(stack: &mut OperandStack) -> Result<ExecutionResult> {
     // The monitorenter instruction is not currently used by this implementation.
     let _ = stack.pop_object()?;
     Ok(Continue)
@@ -13,7 +13,7 @@ pub(crate) fn monitorenter(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.monitorexit>
 #[inline]
-pub(crate) fn monitorexit(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn monitorexit(stack: &mut OperandStack) -> Result<ExecutionResult> {
     // The monitorexit instruction is not currently used by this implementation.
     let _ = stack.pop_object()?;
     Ok(Continue)

--- a/ristretto_vm/src/instruction/object.rs
+++ b/ristretto_vm/src/instruction/object.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aconst_null>
 #[inline]
-pub(crate) fn aconst_null(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aconst_null(stack: &mut OperandStack) -> Result<ExecutionResult> {
     stack.push_object(None)?;
     Ok(Continue)
 }
@@ -19,7 +19,7 @@ pub(crate) fn aconst_null(stack: &OperandStack) -> Result<ExecutionResult> {
 #[inline]
 pub(crate) fn aload(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let object = locals.get_object(usize::from(index))?;
@@ -32,7 +32,7 @@ pub(crate) fn aload(
 #[inline]
 pub(crate) fn aload_w(
     locals: &LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let object = locals.get_object(usize::from(index))?;
@@ -42,7 +42,10 @@ pub(crate) fn aload_w(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aload_n>
 #[inline]
-pub(crate) fn aload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aload_0(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let object = locals.get_object(0)?;
     stack.push_object(object)?;
     Ok(Continue)
@@ -50,7 +53,10 @@ pub(crate) fn aload_0(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aload_n>
 #[inline]
-pub(crate) fn aload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aload_1(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let object = locals.get_object(1)?;
     stack.push_object(object)?;
     Ok(Continue)
@@ -58,7 +64,10 @@ pub(crate) fn aload_1(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aload_n>
 #[inline]
-pub(crate) fn aload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aload_2(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let object = locals.get_object(2)?;
     stack.push_object(object)?;
     Ok(Continue)
@@ -66,7 +75,10 @@ pub(crate) fn aload_2(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aload_n>
 #[inline]
-pub(crate) fn aload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aload_3(
+    locals: &LocalVariables,
+    stack: &mut OperandStack,
+) -> Result<ExecutionResult> {
     let object = locals.get_object(3)?;
     stack.push_object(object)?;
     Ok(Continue)
@@ -76,7 +88,7 @@ pub(crate) fn aload_3(locals: &LocalVariables, stack: &OperandStack) -> Result<E
 #[inline]
 pub(crate) fn astore(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u8,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
@@ -89,7 +101,7 @@ pub(crate) fn astore(
 #[inline]
 pub(crate) fn astore_w(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
     index: u16,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
@@ -101,7 +113,7 @@ pub(crate) fn astore_w(
 #[inline]
 pub(crate) fn astore_0(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
     locals.set_object(0, value)?;
@@ -112,7 +124,7 @@ pub(crate) fn astore_0(
 #[inline]
 pub(crate) fn astore_1(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
     locals.set_object(1, value)?;
@@ -123,7 +135,7 @@ pub(crate) fn astore_1(
 #[inline]
 pub(crate) fn astore_2(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
     locals.set_object(2, value)?;
@@ -134,7 +146,7 @@ pub(crate) fn astore_2(
 #[inline]
 pub(crate) fn astore_3(
     locals: &mut LocalVariables,
-    stack: &OperandStack,
+    stack: &mut OperandStack,
 ) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
     locals.set_object(3, value)?;
@@ -143,7 +155,7 @@ pub(crate) fn astore_3(
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aaload>
 #[inline]
-pub(crate) fn aaload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aaload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -165,7 +177,7 @@ pub(crate) fn aaload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.aastore>
 #[inline]
-pub(crate) fn aastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn aastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {
@@ -190,29 +202,35 @@ pub(crate) fn aastore(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.areturn>
 #[inline]
-pub(crate) fn areturn(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn areturn(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_object()?;
     Ok(Return(Some(Value::Object(value))))
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.new>
 #[inline]
-pub(crate) async fn new(frame: &Frame, index: u16) -> Result<ExecutionResult> {
+pub(crate) async fn new(
+    frame: &Frame,
+    stack: &mut OperandStack,
+    index: u16,
+) -> Result<ExecutionResult> {
     let thread = frame.thread()?;
     let constant_pool = frame.class().constant_pool();
     let class_name = constant_pool.try_get_class(index)?;
     let class = thread.class(class_name).await?;
     let object = Object::new(class)?;
     let reference = Reference::from(object);
-    let stack = frame.stack();
     stack.push_object(Some(reference))?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.checkcast>
 #[inline]
-pub(crate) async fn checkcast(frame: &Frame, class_index: u16) -> Result<ExecutionResult> {
-    let stack = frame.stack();
+pub(crate) async fn checkcast(
+    frame: &Frame,
+    stack: &mut OperandStack,
+    class_index: u16,
+) -> Result<ExecutionResult> {
     let Value::Object(object) = stack.peek()? else {
         return Err(InternalError("Expected object".to_string()));
     };
@@ -239,8 +257,11 @@ pub(crate) async fn checkcast(frame: &Frame, class_index: u16) -> Result<Executi
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.instanceof>
 #[inline]
-pub(crate) async fn instanceof(frame: &Frame, class_index: u16) -> Result<ExecutionResult> {
-    let stack = frame.stack();
+pub(crate) async fn instanceof(
+    frame: &Frame,
+    stack: &mut OperandStack,
+    class_index: u16,
+) -> Result<ExecutionResult> {
     let object = stack.pop_object()?;
     let Some(object) = object else {
         stack.push_int(0)?;
@@ -430,8 +451,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_aaload() -> Result<()> {
-        let (_vm, thread, frame) = crate::test::frame().await?;
-        let stack = frame.stack();
+        let (_vm, thread, _frame) = crate::test::frame().await?;
+        let stack = &mut OperandStack::with_max_size(2);
         let class = thread.class("java/lang/Object").await?;
         let object = Reference::from(vec![42i32]);
         let array = Reference::Array(class, ConcurrentVec::from(vec![Some(object.clone())]));
@@ -462,8 +483,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_aaload_invalid_index() -> Result<()> {
-        let (_vm, thread, frame) = crate::test::frame().await?;
-        let stack = frame.stack();
+        let (_vm, thread, _frame) = crate::test::frame().await?;
+        let stack = &mut OperandStack::with_max_size(2);
         let class = thread.class("java/lang/Object").await?;
         let object = Reference::from(vec![42i32]);
         let array = Reference::Array(class, ConcurrentVec::from(vec![Some(object.clone())]));
@@ -490,8 +511,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_aastore() -> Result<()> {
-        let (_vm, thread, frame) = crate::test::frame().await?;
-        let stack = frame.stack();
+        let (_vm, thread, _frame) = crate::test::frame().await?;
+        let stack = &mut OperandStack::with_max_size(3);
         let class = thread.class("java/lang/Object").await?;
         let object = Reference::from(vec![3i32]);
         let array = Reference::Array(class, ConcurrentVec::from(vec![Some(object)]));
@@ -523,8 +544,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_aastore_invalid_index() -> Result<()> {
-        let (_vm, thread, frame) = crate::test::frame().await?;
-        let stack = frame.stack();
+        let (_vm, thread, _frame) = crate::test::frame().await?;
+        let stack = &mut OperandStack::with_max_size(3);
         let class = thread.class("java/lang/Object").await?;
         let object = Reference::from(vec![3i32]);
         let array = Reference::Array(class, ConcurrentVec::from(vec![Some(object.clone())]));
@@ -592,9 +613,9 @@ mod tests {
         let class = frame.class_mut();
         let constant_pool = Arc::get_mut(class).expect("class").constant_pool_mut();
         let class_index = constant_pool.add_class("Child")?;
-        let process_result = new(&frame, class_index).await?;
+        let stack = &mut OperandStack::with_max_size(1);
+        let process_result = new(&frame, stack, class_index).await?;
         assert_eq!(process_result, Continue);
-        let stack = frame.stack();
         let object = stack.pop()?;
         assert!(matches!(object, Value::Object(Some(Reference::Object(_)))));
         Ok(())
@@ -610,10 +631,10 @@ mod tests {
     #[tokio::test]
     async fn test_checkcast_null() -> Result<()> {
         let (_vm, _thread, mut frame) = crate::test::frame().await?;
-        let stack = &mut frame.stack();
+        let stack = &mut OperandStack::with_max_size(1);
         stack.push_object(None)?;
         let class_index = get_class_index(&mut frame, "java/lang/Object")?;
-        let result = checkcast(&frame, class_index).await?;
+        let result = checkcast(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         Ok(())
     }
@@ -621,11 +642,11 @@ mod tests {
     #[tokio::test]
     async fn test_checkcast_string_to_object() -> Result<()> {
         let (vm, _thread, mut frame) = crate::test::frame().await?;
-        let stack = &mut frame.stack();
+        let stack = &mut OperandStack::with_max_size(1);
         let string = "foo".to_object(&vm).await?;
         stack.push(string)?;
         let class_index = get_class_index(&mut frame, "java/lang/Object")?;
-        let result = checkcast(&frame, class_index).await?;
+        let result = checkcast(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         Ok(())
     }
@@ -633,12 +654,12 @@ mod tests {
     #[tokio::test]
     async fn test_checkcast_object_to_string() -> Result<()> {
         let (_vm, thread, mut frame) = crate::test::frame().await?;
-        let stack = &mut frame.stack();
+        let stack = &mut OperandStack::with_max_size(1);
         let object_class = thread.class("java/lang/Object").await?;
         let object = Object::new(object_class)?;
         stack.push_object(Some(Reference::from(object)))?;
         let class_index = get_class_index(&mut frame, "java/lang/String")?;
-        let result = checkcast(&frame, class_index).await;
+        let result = checkcast(&frame, stack, class_index).await;
         assert!(matches!(
             result,
             Err(JavaError(ClassCastException { source_class_name, target_class_name}))
@@ -650,12 +671,12 @@ mod tests {
     #[tokio::test]
     async fn test_checkcast_string_array_to_object_array() -> Result<()> {
         let (_vm, thread, mut frame) = crate::test::frame().await?;
-        let stack = &mut frame.stack();
+        let stack = &mut OperandStack::with_max_size(1);
         let string_class = thread.class("[Ljava/lang/String;").await?;
         let string_array = Reference::Array(string_class, ConcurrentVec::default());
         stack.push_object(Some(string_array))?;
         let class_index = get_class_index(&mut frame, "[Ljava/lang/Object;")?;
-        let result = checkcast(&frame, class_index).await?;
+        let result = checkcast(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         Ok(())
     }
@@ -663,13 +684,10 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_null() -> Result<()> {
         let (_vm, _thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            stack.push_object(None)?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        stack.push_object(None)?;
         let class_index = get_class_index(&mut frame, "java/lang/Object")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(0, stack.pop_int()?);
         Ok(())
@@ -678,14 +696,11 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_string_to_object() -> Result<()> {
         let (vm, _thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            let string = "foo".to_object(&vm).await?;
-            stack.push(string)?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        let string = "foo".to_object(&vm).await?;
+        stack.push(string)?;
         let class_index = get_class_index(&mut frame, "java/lang/Object")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(1, stack.pop_int()?);
         Ok(())
@@ -694,15 +709,12 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_object_to_string() -> Result<()> {
         let (_vm, thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            let object_class = thread.class("java/lang/Object").await?;
-            let object = Object::new(object_class)?;
-            stack.push_object(Some(Reference::from(object)))?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        let object_class = thread.class("java/lang/Object").await?;
+        let object = Object::new(object_class)?;
+        stack.push_object(Some(Reference::from(object)))?;
         let class_index = get_class_index(&mut frame, "java/lang/String")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(0, stack.pop_int()?);
         Ok(())
@@ -711,15 +723,12 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_string_array_to_object() -> Result<()> {
         let (_vm, thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            let string_class = thread.class("[Ljava/lang/String;").await?;
-            let string_array = Reference::Array(string_class, ConcurrentVec::default());
-            stack.push_object(Some(string_array))?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        let string_class = thread.class("[Ljava/lang/String;").await?;
+        let string_array = Reference::Array(string_class, ConcurrentVec::default());
+        stack.push_object(Some(string_array))?;
         let class_index = get_class_index(&mut frame, "java/lang/Object")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(1, stack.pop_int()?);
         Ok(())
@@ -728,15 +737,12 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_object_array_to_string() -> Result<()> {
         let (_vm, thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            let object_class = thread.class("[Ljava/lang/Object;").await?;
-            let object_array = Reference::Array(object_class, ConcurrentVec::default());
-            stack.push_object(Some(object_array))?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        let object_class = thread.class("[Ljava/lang/Object;").await?;
+        let object_array = Reference::Array(object_class, ConcurrentVec::default());
+        stack.push_object(Some(object_array))?;
         let class_index = get_class_index(&mut frame, "java/lang/String")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(0, stack.pop_int()?);
         Ok(())
@@ -745,14 +751,11 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_int_array_to_int_array() -> Result<()> {
         let (_vm, _thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            let int_array = Reference::from(vec![0i32; 0]);
-            stack.push_object(Some(int_array))?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        let int_array = Reference::from(vec![0i32; 0]);
+        stack.push_object(Some(int_array))?;
         let class_index = get_class_index(&mut frame, "[I")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(1, stack.pop_int()?);
         Ok(())
@@ -761,14 +764,11 @@ mod tests {
     #[tokio::test]
     async fn test_instanceof_long_array_to_int_array() -> Result<()> {
         let (_vm, _thread, mut frame) = crate::test::frame().await?;
-        {
-            let stack = &mut frame.stack();
-            let long_array = Reference::LongArray(ConcurrentVec::default());
-            stack.push_object(Some(long_array))?;
-        }
+        let stack = &mut OperandStack::with_max_size(1);
+        let long_array = Reference::LongArray(ConcurrentVec::default());
+        stack.push_object(Some(long_array))?;
         let class_index = get_class_index(&mut frame, "[I")?;
-        let result = instanceof(&frame, class_index).await?;
-        let stack = &mut frame.stack();
+        let result = instanceof(&frame, stack, class_index).await?;
         assert_eq!(Continue, result);
         assert_eq!(0, stack.pop_int()?);
         Ok(())

--- a/ristretto_vm/src/instruction/push.rs
+++ b/ristretto_vm/src/instruction/push.rs
@@ -5,14 +5,14 @@ use crate::Result;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.bipush>
 #[inline]
-pub(crate) fn bipush(stack: &OperandStack, value: i8) -> Result<ExecutionResult> {
+pub(crate) fn bipush(stack: &mut OperandStack, value: i8) -> Result<ExecutionResult> {
     stack.push_int(i32::from(value))?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.sipush>
 #[inline]
-pub(crate) fn sipush(stack: &OperandStack, value: i16) -> Result<ExecutionResult> {
+pub(crate) fn sipush(stack: &mut OperandStack, value: i16) -> Result<ExecutionResult> {
     stack.push_int(i32::from(value))?;
     Ok(Continue)
 }

--- a/ristretto_vm/src/instruction/short.rs
+++ b/ristretto_vm/src/instruction/short.rs
@@ -8,7 +8,7 @@ use ristretto_classloader::Reference;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.saload>
 #[inline]
-pub(crate) fn saload(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn saload(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let index = stack.pop_int()?;
     match stack.pop_object()? {
         None => Err(NullPointerException("array cannot be null".to_string()).into()),
@@ -30,7 +30,7 @@ pub(crate) fn saload(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.sastore>
 #[inline]
-pub(crate) fn sastore(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn sastore(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop_int()?;
     let index = stack.pop_int()?;
     match stack.pop_object()? {

--- a/ristretto_vm/src/instruction/stack.rs
+++ b/ristretto_vm/src/instruction/stack.rs
@@ -5,14 +5,14 @@ use crate::Result;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.pop>
 #[inline]
-pub(crate) fn pop(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn pop(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let _ = stack.pop()?;
     Ok(Continue)
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.pop2>
 #[inline]
-pub(crate) fn pop2(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn pop2(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop()?;
     if value.is_category_1() {
         let _ = stack.pop()?;
@@ -22,7 +22,7 @@ pub(crate) fn pop2(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dup>
 #[inline]
-pub(crate) fn dup(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dup(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value = stack.pop()?;
     stack.push(value.clone())?;
     stack.push(value)?;
@@ -31,7 +31,7 @@ pub(crate) fn dup(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dup_x1>
 #[inline]
-pub(crate) fn dup_x1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dup_x1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value1 = stack.pop()?;
     let value2 = stack.pop()?;
     stack.push(value1.clone())?;
@@ -42,7 +42,7 @@ pub(crate) fn dup_x1(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dup_x2>
 #[inline]
-pub(crate) fn dup_x2(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dup_x2(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value1 = stack.pop()?;
     let value2 = stack.pop()?;
     if value2.is_category_1() {
@@ -61,7 +61,7 @@ pub(crate) fn dup_x2(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dup2>
 #[inline]
-pub(crate) fn dup2(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dup2(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value1 = stack.pop()?;
     if value1.is_category_1() {
         let value2 = stack.pop()?;
@@ -78,7 +78,7 @@ pub(crate) fn dup2(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dup2_x1>
 #[inline]
-pub(crate) fn dup2_x1(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dup2_x1(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value1 = stack.pop()?;
     let value2 = stack.pop()?;
     if value1.is_category_1() {
@@ -98,7 +98,7 @@ pub(crate) fn dup2_x1(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.dup2_x2>
 #[inline]
-pub(crate) fn dup2_x2(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn dup2_x2(stack: &mut OperandStack) -> Result<ExecutionResult> {
     let value1 = stack.pop()?;
     let value2 = stack.pop()?;
     if value1.is_category_1() {
@@ -130,7 +130,7 @@ pub(crate) fn dup2_x2(stack: &OperandStack) -> Result<ExecutionResult> {
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-6.html#jvms-6.5.swap>
 #[inline]
-pub(crate) fn swap(stack: &OperandStack) -> Result<ExecutionResult> {
+pub(crate) fn swap(stack: &mut OperandStack) -> Result<ExecutionResult> {
     // Swapping category 2 values (Double and Long) is not supported by the JVM specification and
     // there is no mention of what should happen in this case. We will just swap the values and
     // ignore the fact that category 2 values could be swapped here.
@@ -152,7 +152,7 @@ mod test {
         stack.push_object(None)?;
         let result = pop(stack)?;
         assert_eq!(Continue, result);
-        assert!(stack.is_empty()?);
+        assert!(stack.is_empty());
         Ok(())
     }
 
@@ -163,7 +163,7 @@ mod test {
         stack.push_object(None)?;
         let result = pop2(stack)?;
         assert_eq!(Continue, result);
-        assert!(stack.is_empty()?);
+        assert!(stack.is_empty());
         Ok(())
     }
 
@@ -173,7 +173,7 @@ mod test {
         stack.push_long(42)?;
         let result = pop2(stack)?;
         assert_eq!(Continue, result);
-        assert!(stack.is_empty()?);
+        assert!(stack.is_empty());
         Ok(())
     }
 

--- a/ristretto_vm/src/operand_stack.rs
+++ b/ristretto_vm/src/operand_stack.rs
@@ -1,6 +1,6 @@
 use crate::Error::{InvalidOperand, OperandStackOverflow, OperandStackUnderflow};
 use crate::Result;
-use ristretto_classloader::{ConcurrentVec, Reference, Value};
+use ristretto_classloader::{Reference, Value};
 use std::fmt::Display;
 
 /// Operand stack for the Ristretto VM
@@ -8,63 +8,63 @@ use std::fmt::Display;
 /// See: <https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-2.html#jvms-2.6.2>
 #[derive(Debug)]
 pub struct OperandStack {
-    stack: ConcurrentVec<Value>,
+    stack: Vec<Value>,
 }
 
 impl OperandStack {
     /// Create a new operand stack with a maximum size.
     pub fn with_max_size(max_size: usize) -> Self {
         OperandStack {
-            stack: ConcurrentVec::with_capacity(max_size),
+            stack: Vec::with_capacity(max_size),
         }
     }
 
     /// Push a value onto the operand stack.
     #[inline]
-    pub fn push(&self, value: Value) -> Result<()> {
-        if self.stack.len()? >= self.stack.capacity()? {
+    pub fn push(&mut self, value: Value) -> Result<()> {
+        if self.stack.len() >= self.stack.capacity() {
             return Err(OperandStackOverflow);
         }
-        self.stack.push(value)?;
+        self.stack.push(value);
         Ok(())
     }
 
     /// Push an int value onto the operand stack.
-    pub fn push_int(&self, value: i32) -> Result<()> {
+    pub fn push_int(&mut self, value: i32) -> Result<()> {
         self.push(Value::Int(value))
     }
 
     /// Push a long value onto the operand stack.
-    pub fn push_long(&self, value: i64) -> Result<()> {
+    pub fn push_long(&mut self, value: i64) -> Result<()> {
         self.push(Value::Long(value))
     }
 
     /// Push a float value onto the operand stack.
-    pub fn push_float(&self, value: f32) -> Result<()> {
+    pub fn push_float(&mut self, value: f32) -> Result<()> {
         self.push(Value::Float(value))
     }
 
     /// Push a double value onto the operand stack.
-    pub fn push_double(&self, value: f64) -> Result<()> {
+    pub fn push_double(&mut self, value: f64) -> Result<()> {
         self.push(Value::Double(value))
     }
 
     /// Push a reference onto the operand stack.
-    pub fn push_object(&self, value: Option<Reference>) -> Result<()> {
+    pub fn push_object(&mut self, value: Option<Reference>) -> Result<()> {
         self.push(Value::Object(value))
     }
 
     /// Pop a value from the operand stack.
     #[inline]
-    pub fn pop(&self) -> Result<Value> {
-        let Ok(Some(value)) = self.stack.pop() else {
+    pub fn pop(&mut self) -> Result<Value> {
+        let Some(value) = self.stack.pop() else {
             return Err(OperandStackUnderflow);
         };
         Ok(value)
     }
 
     /// Pop an int from the operand stack.
-    pub fn pop_int(&self) -> Result<i32> {
+    pub fn pop_int(&mut self) -> Result<i32> {
         match self.pop()? {
             Value::Int(value) => Ok(value),
             value => Err(InvalidOperand {
@@ -75,7 +75,7 @@ impl OperandStack {
     }
 
     /// Pop a long from the operand stack.
-    pub fn pop_long(&self) -> Result<i64> {
+    pub fn pop_long(&mut self) -> Result<i64> {
         let value = match self.pop()? {
             Value::Long(value) => value,
             value => {
@@ -89,7 +89,7 @@ impl OperandStack {
     }
 
     /// Pop a float from the operand stack.
-    pub fn pop_float(&self) -> Result<f32> {
+    pub fn pop_float(&mut self) -> Result<f32> {
         match self.pop()? {
             Value::Float(value) => Ok(value),
             value => Err(InvalidOperand {
@@ -100,7 +100,7 @@ impl OperandStack {
     }
 
     /// Pop a double from the operand stack.
-    pub fn pop_double(&self) -> Result<f64> {
+    pub fn pop_double(&mut self) -> Result<f64> {
         let value = match self.pop()? {
             Value::Double(value) => value,
             value => {
@@ -114,7 +114,7 @@ impl OperandStack {
     }
 
     /// Pop a null or object from the operand stack.
-    pub fn pop_object(&self) -> Result<Option<Reference>> {
+    pub fn pop_object(&mut self) -> Result<Option<Reference>> {
         let value = self.pop()?;
         match value {
             Value::Object(reference) => Ok(reference),
@@ -126,46 +126,39 @@ impl OperandStack {
     }
 
     /// Peek at the top value on the operand stack.
-    pub fn peek(&self) -> Result<Value> {
-        let Ok(Some(value)) = self.stack.pop() else {
+    pub fn peek(&mut self) -> Result<Value> {
+        let Some(value) = self.stack.iter().last() else {
             return Err(OperandStackUnderflow);
         };
-        self.stack.push(value.clone())?;
-        Ok(value)
+        Ok(value.clone())
     }
 
     /// Get the number of values on the operand stack.
-    pub fn len(&self) -> Result<usize> {
-        Ok(self.stack.len()?)
+    pub fn len(&self) -> usize {
+        self.stack.len()
     }
 
     /// Check if the operand stack is empty.
-    pub fn is_empty(&self) -> Result<bool> {
-        Ok(self.stack.is_empty()?)
+    pub fn is_empty(&self) -> bool {
+        self.stack.is_empty()
     }
 }
 
 impl Display for OperandStack {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.stack.to_vec() {
-            Ok(stack) => {
-                let mut values = Vec::new();
-                for stack_entry in &stack {
-                    let value = stack_entry.to_string();
-                    let chars: Vec<char> = value.chars().collect();
-                    if chars.len() > 100 {
-                        let value = chars.iter().take(97).collect::<String>();
-                        values.push(format!("{value}..."));
-                    } else {
-                        values.push(value);
-                    }
-                }
-                write!(f, "[{}]", values.join(", "))
-            }
-            Err(error) => {
-                write!(f, "poisoned lock: {error}")
+        let mut values = Vec::new();
+        let stack = &self.stack;
+        for stack_entry in stack {
+            let value = stack_entry.to_string();
+            let chars: Vec<char> = value.chars().collect();
+            if chars.len() > 100 {
+                let value = chars.iter().take(97).collect::<String>();
+                values.push(format!("{value}..."));
+            } else {
+                values.push(value);
             }
         }
+        write!(f, "[{}]", values.join(", "))
     }
 }
 
@@ -177,11 +170,11 @@ mod tests {
 
     #[test]
     fn test_can_push_and_pop_values() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         stack.push_int(1)?;
         stack.push_int(2)?;
 
-        assert_eq!(stack.len()?, 2);
+        assert_eq!(stack.len(), 2);
 
         assert_eq!(stack.pop()?, Value::Int(2));
         assert_eq!(stack.pop()?, Value::Int(1));
@@ -190,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_pop_int() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         stack.push_int(42)?;
         assert_eq!(stack.pop_int()?, 42);
         Ok(())
@@ -198,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_pop_int_invalid_operand() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         stack.push_object(None)?;
         assert!(matches!(
             stack.pop_int(),
@@ -212,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_pop_long() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         stack.push_long(42)?;
         assert_eq!(stack.pop_long()?, 42);
         Ok(())
@@ -220,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_pop_long_invalid_operand() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         stack.push_double(42.1)?;
         assert!(matches!(
             stack.pop_long(),
@@ -234,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_pop_float() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         stack.push_float(42.1)?;
         let value = stack.pop_float()? - 42.1f32;
         assert!(value.abs() < 0.1f32);
@@ -243,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_pop_float_invalid_operand() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         stack.push_object(None)?;
         assert!(matches!(
             stack.pop_float(),
@@ -257,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_pop_double() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         stack.push_double(42.1)?;
         let value = stack.pop_double()? - 42.1f64;
         assert!(value.abs() < 0.1f64);
@@ -266,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_pop_double_invalid_operand() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         stack.push_long(42)?;
         assert!(matches!(
             stack.pop_double(),
@@ -280,7 +273,7 @@ mod tests {
 
     #[test]
     fn test_pop_object() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         let object = Reference::ByteArray(ConcurrentVec::from(vec![42]));
         stack.push_object(None)?;
         stack.push_object(Some(object.clone()))?;
@@ -291,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_pop_object_invalid_operand() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         stack.push_int(42)?;
         assert!(matches!(
             stack.pop_object(),
@@ -305,14 +298,14 @@ mod tests {
 
     #[test]
     fn test_pop_underflow() {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         let result = stack.pop();
         assert!(matches!(result, Err(OperandStackUnderflow)));
     }
 
     #[test]
     fn test_push_overflow() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         stack.push_int(42)?;
         let result = stack.push_int(43);
         assert!(matches!(result, Err(OperandStackOverflow)));
@@ -321,35 +314,35 @@ mod tests {
 
     #[test]
     fn test_peek_top_value() -> Result<()> {
-        let stack = OperandStack::with_max_size(2);
+        let mut stack = OperandStack::with_max_size(2);
         stack.push_int(1)?;
         stack.push_int(2)?;
 
         assert_eq!(stack.peek()?, Value::Int(2));
-        assert_eq!(stack.len()?, 2);
+        assert_eq!(stack.len(), 2);
         Ok(())
     }
 
     #[test]
     fn test_peek_underflow() {
-        let stack = OperandStack::with_max_size(1);
+        let mut stack = OperandStack::with_max_size(1);
         let result = stack.peek();
         assert!(matches!(result, Err(OperandStackUnderflow)));
     }
 
     #[test]
     fn test_is_empty() -> Result<()> {
-        let stack = OperandStack::with_max_size(1);
-        assert!(stack.is_empty()?);
+        let mut stack = OperandStack::with_max_size(1);
+        assert!(stack.is_empty());
 
         stack.push_int(42)?;
-        assert!(!stack.is_empty()?);
+        assert!(!stack.is_empty());
         Ok(())
     }
 
     #[test]
     fn test_display() -> Result<()> {
-        let stack = OperandStack::with_max_size(4);
+        let mut stack = OperandStack::with_max_size(4);
         stack.push_int(1)?;
         stack.push_int(2)?;
         assert_eq!("[int(1), int(2)]", stack.to_string());


### PR DESCRIPTION
Thanks to @FractalFir for the suggestion to remove the unnecessary use of Arc / locking for LocalVariables!