### PR TITLE
feat: optimize jit Instruction::Return

### DIFF
--- a/ristretto_jit/src/instruction/branch.rs
+++ b/ristretto_jit/src/instruction/branch.rs
@@ -1,17 +1,18 @@
-use crate::jit_value;
 use cranelift::frontend::FunctionBuilder;
-use cranelift::prelude::{InstBuilder, MemFlags, Value, types};
+use cranelift::prelude::{InstBuilder, Value};
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.return>
-pub(crate) fn r#return(function_builder: &mut FunctionBuilder, return_pointer: Value) {
-    let value = function_builder.ins().iconst(types::I64, 0);
-    let discriminate = i64::from(jit_value::NONE);
-    let discriminate = function_builder.ins().iconst(types::I8, discriminate);
-    function_builder
-        .ins()
-        .store(MemFlags::new(), discriminate, return_pointer, 0);
-    function_builder
-        .ins()
-        .store(MemFlags::new(), value, return_pointer, 8);
+pub(crate) fn r#return(function_builder: &mut FunctionBuilder, _return_pointer: Value) {
+    // This optimization relies on the fact that when returning from a "void" method, the default
+    // return pointer values should be initialized to 0 which is the same as the following code:
+    // let value = function_builder.ins().iconst(types::I64, 0);
+    // let discriminate = i64::from(jit_value::NONE);
+    // let discriminate = function_builder.ins().iconst(types::I8, discriminate);
+    // function_builder
+    //     .ins()
+    //     .store(MemFlags::new(), discriminate, return_pointer, 0);
+    // function_builder
+    //     .ins()
+    //     .store(MemFlags::new(), value, return_pointer, 8);
     function_builder.ins().return_(&[]);
 }

--- a/ristretto_jit/tests/object_init.rs
+++ b/ristretto_jit/tests/object_init.rs
@@ -1,0 +1,45 @@
+use ristretto_classfile::attributes::{Attribute, Instruction, MaxLocals, MaxStack};
+use ristretto_classfile::{ClassAccessFlags, ClassFile, ConstantPool, MethodAccessFlags};
+use ristretto_jit::{Compiler, Result};
+
+#[test]
+fn compile_object_init() -> Result<()> {
+    let mut constant_pool = ConstantPool::default();
+    let class_name_index = constant_pool.add_class("Test")?;
+    let code_index = constant_pool.add_utf8("Code")?;
+    let test_name_index = constant_pool.add_utf8("<init>>")?;
+    let test_descriptor_index = constant_pool.add_utf8("()V")?;
+
+    let mut test_method = ristretto_classfile::Method {
+        access_flags: MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+        name_index: test_name_index,
+        descriptor_index: test_descriptor_index,
+        attributes: Vec::new(),
+    };
+    let test_method_code = vec![Instruction::Return];
+    let test_max_stack = test_method_code.max_stack(&constant_pool)?;
+    let test_max_locals = test_method_code.max_locals(&constant_pool, test_descriptor_index)?;
+    test_method.attributes.push(Attribute::Code {
+        name_index: code_index,
+        max_stack: test_max_stack,
+        max_locals: test_max_locals,
+        code: test_method_code,
+        exception_table: Vec::new(),
+        attributes: Vec::new(),
+    });
+    let class_file = ClassFile {
+        constant_pool,
+        access_flags: ClassAccessFlags::PUBLIC,
+        this_class: class_name_index,
+        methods: vec![test_method],
+        attributes: Vec::new(),
+        ..Default::default()
+    };
+    let test_method = &class_file.methods[0];
+
+    let mut compiler = Compiler::new()?;
+    let function = compiler.compile(&class_file, test_method)?;
+    let value = function.execute(Vec::new())?;
+    assert_eq!(value, None);
+    Ok(())
+}


### PR DESCRIPTION
This change avoids opcodes to set the return value to none for `Instruction::Return`.  Example for `java.jang.Object.<init>()`:

**Before**
```
function u0:4(i64, i64, i64) apple_aarch64 {
block0(v0: i64, v1: i64, v2: i64):
    v5 = iconst.i8 0
    store v5, v2  ; v5 = 0
    v4 = iconst.i64 0
    store v4, v2+8  ; v4 = 0
    return
}
```

**After**

```
function u0:4(i64, i64, i64) apple_aarch64 {
block0(v0: i64, v1: i64, v2: i64):
    return
}
```