### PR TITLE
feat: optimize operand stack layout

### DIFF
--- a/ristretto_jit/src/operand_stack.rs
+++ b/ristretto_jit/src/operand_stack.rs
@@ -2,11 +2,20 @@ use crate::Error::InternalError;
 use crate::Result;
 use cranelift::codegen::ir::{StackSlot, Value};
 use cranelift::frontend::FunctionBuilder;
-use cranelift::prelude::{InstBuilder, StackSlotData, StackSlotKind, types};
+use cranelift::prelude::{InstBuilder, StackSlotData, StackSlotKind, Type, types};
 
 const POINTER_SIZE: i32 = 8;
 
 /// Operand stack for the JIT compiler.
+///
+/// The stack is implemented as a continuous array of 64bit/8byte values.  I32 and F32 values are
+/// padded to 8 bytes.  The stack is aligned to 8 bytes for performance reasons.
+///
+/// ```text
+/// |------- 8 bytes -------|----- 8 bytes -----|------- 8 bytes -------|----- 8 bytes -----|
+/// |- 4 bytes -|- 4 bytes -|                   |- 4 bytes -|- 4 bytes -|                   |
+/// |  padding  |    I32    |        I64        |  padding  |    F32    |        F64        |
+/// ```
 pub struct OperandStack {
     slot: Option<StackSlot>,
     length: i32,
@@ -32,7 +41,12 @@ impl OperandStack {
     }
 
     /// Pushes a value onto the stack.
-    pub fn push(&mut self, function_builder: &mut FunctionBuilder, value: Value) -> Result<()> {
+    fn push_type(
+        &mut self,
+        function_builder: &mut FunctionBuilder,
+        value_type: Type,
+        value: Value,
+    ) -> Result<()> {
         let Some(slot) = self.slot else {
             return Err(InternalError(
                 "OperandStack.slot is not initialized".to_string(),
@@ -41,14 +55,22 @@ impl OperandStack {
         let index = self.length;
         self.length = index + 1;
         let slot_index = index.saturating_mul(POINTER_SIZE);
+        let value_type_bytes = value_type.bytes();
+        let padding = POINTER_SIZE.saturating_sub_unsigned(value_type_bytes);
+        let slot_index = slot_index.saturating_add(padding);
         function_builder.ins().stack_store(value, slot, slot_index);
         Ok(())
     }
 
+    /// Pushes a value onto the stack.
+    pub fn push(&mut self, function_builder: &mut FunctionBuilder, value: Value) -> Result<()> {
+        // Default to I64/8-bytes.
+        self.push_type(function_builder, types::I64, value)
+    }
+
     /// Push an int value onto the operand stack.
     pub fn push_int(&mut self, function_builder: &mut FunctionBuilder, value: Value) -> Result<()> {
-        let value = function_builder.ins().sextend(types::I64, value);
-        self.push(function_builder, value)
+        self.push_type(function_builder, types::I32, value)
     }
 
     /// Push a long value onto the operand stack.
@@ -57,7 +79,7 @@ impl OperandStack {
         function_builder: &mut FunctionBuilder,
         value: Value,
     ) -> Result<()> {
-        self.push(function_builder, value)
+        self.push_type(function_builder, types::I64, value)
     }
 
     /// Push a float value onto the operand stack.
@@ -66,8 +88,7 @@ impl OperandStack {
         function_builder: &mut FunctionBuilder,
         value: Value,
     ) -> Result<()> {
-        let value = function_builder.ins().fcvt_to_sint(types::I64, value);
-        self.push(function_builder, value)
+        self.push_type(function_builder, types::F32, value)
     }
 
     /// Push a double value onto the operand stack.
@@ -76,12 +97,15 @@ impl OperandStack {
         function_builder: &mut FunctionBuilder,
         value: Value,
     ) -> Result<()> {
-        let value = function_builder.ins().fcvt_to_sint(types::I64, value);
-        self.push(function_builder, value)
+        self.push_type(function_builder, types::F64, value)
     }
 
     /// Pops a value from the stack.
-    pub fn pop(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
+    fn pop_type(
+        &mut self,
+        function_builder: &mut FunctionBuilder,
+        value_type: Type,
+    ) -> Result<Value> {
         let Some(slot) = self.slot else {
             return Err(InternalError(
                 "OperandStack.slot is not initialized".to_string(),
@@ -89,36 +113,39 @@ impl OperandStack {
         };
         let index = self.length - 1;
         let slot_index = index.saturating_mul(POINTER_SIZE);
+        let value_type_bytes = value_type.bytes();
+        let padding = POINTER_SIZE.saturating_sub_unsigned(value_type_bytes);
+        let slot_index = slot_index.saturating_add(padding);
         let value = function_builder
             .ins()
-            .stack_load(types::I64, slot, slot_index);
+            .stack_load(value_type, slot, slot_index);
         self.length = index;
         Ok(value)
     }
 
+    /// Pops a value from the stack.
+    pub fn pop(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
+        // Default to I64/8-bytes.
+        self.pop_type(function_builder, types::I64)
+    }
+
     /// Pop an int from the operand stack.
     pub fn pop_int(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        let value = self.pop(function_builder)?;
-        let value = function_builder.ins().ireduce(types::I32, value);
-        Ok(value)
+        self.pop_type(function_builder, types::I32)
     }
 
     /// Pop a long from the operand stack.
     pub fn pop_long(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        self.pop(function_builder)
+        self.pop_type(function_builder, types::I64)
     }
 
     /// Pop a float from the operand stack.
     pub fn pop_float(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        let value = self.pop(function_builder)?;
-        let value = function_builder.ins().fcvt_from_sint(types::F32, value);
-        Ok(value)
+        self.pop_type(function_builder, types::F32)
     }
 
     /// Pop a double from the operand stack.
     pub fn pop_double(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        let value = self.pop(function_builder)?;
-        let value = function_builder.ins().fcvt_from_sint(types::F64, value);
-        Ok(value)
+        self.pop_type(function_builder, types::F64)
     }
 }


### PR DESCRIPTION
Optimize `OperandStack` by padding `I32`/`F32` values within an 8 byte stack slot to remove unnecessary `sextend`/`ireduce` operations.  Example for `java.util.concurrent.ConcurrentHashMap.spread(I)I`:

**Before**
```
function u0:111(i64, i64, i64) apple_aarch64 {
    ss0 = explicit_slot 24

block0(v0: i64, v1: i64, v2: i64):
    v7 = load.i32 notrap aligned v0+8
    v8 = sextend.i64 v7
    v38 = stack_addr.i64 ss0
    store notrap v8, v38
    v39 = stack_addr.i64 ss0+8
    store notrap v8, v39
    v3 = iconst.i64 16
    v40 = stack_addr.i64 ss0+16
    store notrap v3, v40  ; v3 = 16
    v14 = load.i64 notrap v39
    v15 = ireduce.i32 v14
    v10 = iconst.i32 16
    v18 = ushr v15, v10  ; v10 = 16
    v19 = sextend.i64 v18
    store notrap v19, v39
    v22 = load.i64 notrap v38
    v23 = ireduce.i32 v22
    v24 = bxor v23, v18
    v25 = sextend.i64 v24
    store notrap v25, v38
    v66 = iconst.i64 0x7fff_ffff
    store notrap v66, v39  ; v66 = 0x7fff_ffff
    v30 = load.i64 notrap v38
    v31 = ireduce.i32 v30
    v26 = iconst.i32 0x7fff_ffff
    v32 = band v31, v26  ; v26 = 0x7fff_ffff
    v33 = sextend.i64 v32
    store notrap v33, v38
    v37 = iconst.i8 1
    store v37, v2  ; v37 = 1
    store v33, v2+8
    return
}
```

**After**

```
function u0:111(i64, i64, i64) apple_aarch64 {
    ss0 = explicit_slot 24

block0(v0: i64, v1: i64, v2: i64):
    v7 = load.i32 notrap aligned v0+8
    v24 = stack_addr.i64 ss0+4
    store notrap v7, v24
    v25 = stack_addr.i64 ss0+12
    store notrap v7, v25
    v8 = iconst.i32 16
    v26 = stack_addr.i64 ss0+20
    store notrap v8, v26  ; v8 = 16
    v10 = load.i32 notrap v25
    v13 = ushr v10, v8  ; v8 = 16
    store notrap v13, v25
    v15 = load.i32 notrap v24
    v16 = bxor v15, v13
    store notrap v16, v24
    v17 = iconst.i32 0x7fff_ffff
    store notrap v17, v25  ; v17 = 0x7fff_ffff
    v19 = load.i32 notrap v24
    v20 = band v19, v17  ; v17 = 0x7fff_ffff
    store notrap v20, v24
    v23 = iconst.i8 1
    store v23, v2  ; v23 = 1
    v22 = sextend.i64 v20
    store v22, v2+8
    return
}
```