### PR TITLE
refactor: refactor to use block params for OperandStack

### DIFF
--- a/ristretto_jit/src/compiler.rs
+++ b/ristretto_jit/src/compiler.rs
@@ -111,13 +111,12 @@ impl Compiler {
         let block = function_builder.create_block();
         function_builder.switch_to_block(block);
         function_builder.append_block_params_for_function_params(block);
-
         let (arguments_pointer, _arguments_length_pointer, return_pointer) =
             Self::function_pointers(&mut function_builder, block)?;
 
         let mut locals = Self::locals(method_descriptor, &mut function_builder, arguments_pointer)?;
 
-        let mut stack = OperandStack::with_capacity(&mut function_builder, max_stack)?;
+        let mut stack = OperandStack::with_capacity(max_stack);
         for instruction in instructions {
             Self::process_instruction(
                 constant_pool,
@@ -361,15 +360,15 @@ impl Compiler {
             // Instruction::Bastore => bastore(stack),
             // Instruction::Castore => castore(stack),
             // Instruction::Sastore => sastore(stack),
-            Instruction::Pop => pop(function_builder, stack)?,
+            Instruction::Pop => pop(stack)?,
             Instruction::Pop2 => pop2(function_builder, stack)?,
-            Instruction::Dup => dup(function_builder, stack)?,
-            Instruction::Dup_x1 => dup_x1(function_builder, stack)?,
+            Instruction::Dup => dup(stack)?,
+            Instruction::Dup_x1 => dup_x1(stack)?,
             Instruction::Dup_x2 => dup_x2(function_builder, stack)?,
             Instruction::Dup2 => dup2(function_builder, stack)?,
             Instruction::Dup2_x1 => dup2_x1(function_builder, stack)?,
             Instruction::Dup2_x2 => dup2_x2(function_builder, stack)?,
-            Instruction::Swap => swap(function_builder, stack)?,
+            Instruction::Swap => swap(stack)?,
             Instruction::Iadd => iadd(function_builder, stack)?,
             Instruction::Ladd => ladd(function_builder, stack)?,
             Instruction::Fadd => fadd(function_builder, stack)?,
@@ -483,8 +482,8 @@ impl Compiler {
             // Instruction::Athrow => athrow(stack).await,
             // Instruction::Checkcast(class_index) => checkcast(self, stack, *class_index).await,
             // Instruction::Instanceof(class_index) => instanceof(self, stack, *class_index).await,
-            Instruction::Monitorenter => monitorenter(function_builder, stack)?,
-            Instruction::Monitorexit => monitorexit(function_builder, stack)?,
+            Instruction::Monitorenter => monitorenter(stack)?,
+            Instruction::Monitorexit => monitorexit(stack)?,
             Instruction::Wide => wide()?,
             // Instruction::Multianewarray(index, dimensions) => {
             //     multianewarray(self, stack, *index, *dimensions).await

--- a/ristretto_jit/src/instruction/ldc.rs
+++ b/ristretto_jit/src/instruction/ldc.rs
@@ -94,11 +94,11 @@ pub(crate) fn ldc2_w(
     match constant {
         Constant::Long(value) => {
             let value = function_builder.ins().iconst(types::I64, *value);
-            stack.push(function_builder, value)?;
+            stack.push(value)?;
         }
         Constant::Double(value) => {
             let value = function_builder.ins().f64const(*value);
-            stack.push(function_builder, value)?;
+            stack.push(value)?;
         }
         constant => {
             return Err(InvalidConstant {

--- a/ristretto_jit/src/instruction/monitor.rs
+++ b/ristretto_jit/src/instruction/monitor.rs
@@ -1,23 +1,16 @@
 use crate::Result;
 use crate::operand_stack::OperandStack;
-use cranelift::frontend::FunctionBuilder;
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.monitorenter>
-pub(crate) fn monitorenter(
-    function_builder: &mut FunctionBuilder,
-    stack: &mut OperandStack,
-) -> Result<()> {
+pub(crate) fn monitorenter(stack: &mut OperandStack) -> Result<()> {
     // The monitorenter instruction is not currently used by this implementation.
-    let _ = stack.pop(function_builder)?;
+    let _ = stack.pop()?;
     Ok(())
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.monitorexit>
-pub(crate) fn monitorexit(
-    function_builder: &mut FunctionBuilder,
-    stack: &mut OperandStack,
-) -> Result<()> {
+pub(crate) fn monitorexit(stack: &mut OperandStack) -> Result<()> {
     // The monitorexit instruction is not currently used by this implementation.
-    let _ = stack.pop(function_builder)?;
+    let _ = stack.pop()?;
     Ok(())
 }

--- a/ristretto_jit/src/instruction/stack.rs
+++ b/ristretto_jit/src/instruction/stack.rs
@@ -13,38 +13,35 @@ fn is_category_1(function_builder: &mut FunctionBuilder, value: Value) -> bool {
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.pop>
-pub(crate) fn pop(function_builder: &mut FunctionBuilder, stack: &mut OperandStack) -> Result<()> {
-    let _ = stack.pop(function_builder)?;
+pub(crate) fn pop(stack: &mut OperandStack) -> Result<()> {
+    let _ = stack.pop()?;
     Ok(())
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.pop2>
 pub(crate) fn pop2(function_builder: &mut FunctionBuilder, stack: &mut OperandStack) -> Result<()> {
-    let value = stack.pop(function_builder)?;
+    let value = stack.pop()?;
     if is_category_1(function_builder, value) {
-        let _ = stack.pop(function_builder)?;
+        let _ = stack.pop()?;
     }
     Ok(())
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.dup>
-pub(crate) fn dup(function_builder: &mut FunctionBuilder, stack: &mut OperandStack) -> Result<()> {
-    let value = stack.pop(function_builder)?;
-    stack.push(function_builder, value)?;
-    stack.push(function_builder, value)?;
+pub(crate) fn dup(stack: &mut OperandStack) -> Result<()> {
+    let value = stack.pop()?;
+    stack.push(value)?;
+    stack.push(value)?;
     Ok(())
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.dup_x1>
-pub(crate) fn dup_x1(
-    function_builder: &mut FunctionBuilder,
-    stack: &mut OperandStack,
-) -> Result<()> {
-    let value1 = stack.pop(function_builder)?;
-    let value2 = stack.pop(function_builder)?;
-    stack.push(function_builder, value1)?;
-    stack.push(function_builder, value2)?;
-    stack.push(function_builder, value1)?;
+pub(crate) fn dup_x1(stack: &mut OperandStack) -> Result<()> {
+    let value1 = stack.pop()?;
+    let value2 = stack.pop()?;
+    stack.push(value1)?;
+    stack.push(value2)?;
+    stack.push(value1)?;
     Ok(())
 }
 
@@ -53,34 +50,34 @@ pub(crate) fn dup_x2(
     function_builder: &mut FunctionBuilder,
     stack: &mut OperandStack,
 ) -> Result<()> {
-    let value1 = stack.pop(function_builder)?;
-    let value2 = stack.pop(function_builder)?;
+    let value1 = stack.pop()?;
+    let value2 = stack.pop()?;
     if is_category_1(function_builder, value2) {
-        let value3 = stack.pop(function_builder)?;
-        stack.push(function_builder, value1)?;
-        stack.push(function_builder, value3)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        let value3 = stack.pop()?;
+        stack.push(value1)?;
+        stack.push(value3)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     } else {
-        stack.push(function_builder, value1)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        stack.push(value1)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     }
     Ok(())
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.dup2>
 pub(crate) fn dup2(function_builder: &mut FunctionBuilder, stack: &mut OperandStack) -> Result<()> {
-    let value1 = stack.pop(function_builder)?;
+    let value1 = stack.pop()?;
     if is_category_1(function_builder, value1) {
-        let value2 = stack.pop(function_builder)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        let value2 = stack.pop()?;
+        stack.push(value2)?;
+        stack.push(value1)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     } else {
-        stack.push(function_builder, value1)?;
-        stack.push(function_builder, value1)?;
+        stack.push(value1)?;
+        stack.push(value1)?;
     }
     Ok(())
 }
@@ -90,19 +87,19 @@ pub(crate) fn dup2_x1(
     function_builder: &mut FunctionBuilder,
     stack: &mut OperandStack,
 ) -> Result<()> {
-    let value1 = stack.pop(function_builder)?;
-    let value2 = stack.pop(function_builder)?;
+    let value1 = stack.pop()?;
+    let value2 = stack.pop()?;
     if is_category_1(function_builder, value1) {
-        let value3 = stack.pop(function_builder)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
-        stack.push(function_builder, value3)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        let value3 = stack.pop()?;
+        stack.push(value2)?;
+        stack.push(value1)?;
+        stack.push(value3)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     } else {
-        stack.push(function_builder, value1)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        stack.push(value1)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     }
     Ok(())
 }
@@ -112,43 +109,43 @@ pub(crate) fn dup2_x2(
     function_builder: &mut FunctionBuilder,
     stack: &mut OperandStack,
 ) -> Result<()> {
-    let value1 = stack.pop(function_builder)?;
-    let value2 = stack.pop(function_builder)?;
+    let value1 = stack.pop()?;
+    let value2 = stack.pop()?;
     if is_category_1(function_builder, value1) {
-        let value3 = stack.pop(function_builder)?;
+        let value3 = stack.pop()?;
         if is_category_1(function_builder, value3) {
-            let value4 = stack.pop(function_builder)?;
-            stack.push(function_builder, value2)?;
-            stack.push(function_builder, value1)?;
-            stack.push(function_builder, value4)?;
+            let value4 = stack.pop()?;
+            stack.push(value2)?;
+            stack.push(value1)?;
+            stack.push(value4)?;
         } else {
-            stack.push(function_builder, value1)?;
+            stack.push(value1)?;
         }
-        stack.push(function_builder, value3)?;
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        stack.push(value3)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     } else {
         if is_category_1(function_builder, value2) {
-            let value3 = stack.pop(function_builder)?;
-            stack.push(function_builder, value1)?;
-            stack.push(function_builder, value3)?;
+            let value3 = stack.pop()?;
+            stack.push(value1)?;
+            stack.push(value3)?;
         } else {
-            stack.push(function_builder, value1)?;
+            stack.push(value1)?;
         }
-        stack.push(function_builder, value2)?;
-        stack.push(function_builder, value1)?;
+        stack.push(value2)?;
+        stack.push(value1)?;
     }
     Ok(())
 }
 
 /// See: <https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-6.html#jvms-6.5.swap>
-pub(crate) fn swap(function_builder: &mut FunctionBuilder, stack: &mut OperandStack) -> Result<()> {
+pub(crate) fn swap(stack: &mut OperandStack) -> Result<()> {
     // Swapping category 2 values (Double and Long) is not supported by the JVM specification and
     // there is no mention of what should happen in this case. We will just swap the values and
     // ignore the fact that category 2 values could be swapped here.
-    let value1 = stack.pop(function_builder)?;
-    let value2 = stack.pop(function_builder)?;
-    stack.push(function_builder, value1)?;
-    stack.push(function_builder, value2)?;
+    let value1 = stack.pop()?;
+    let value2 = stack.pop()?;
+    stack.push(value1)?;
+    stack.push(value2)?;
     Ok(())
 }

--- a/ristretto_jit/src/local_variables.rs
+++ b/ristretto_jit/src/local_variables.rs
@@ -31,7 +31,15 @@ impl LocalVariables {
     /// # Errors
     /// if the local variable at the given index was not found or if the value is not an int.
     pub fn get_int(&self, function_builder: &mut FunctionBuilder, index: usize) -> Result<Value> {
-        self.get(function_builder, index)
+        let expected_type = types::I32;
+        let value = self.get(function_builder, index)?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Get a long from the local variables.
@@ -39,7 +47,15 @@ impl LocalVariables {
     /// # Errors
     /// if the local variable at the given index was not found or if the value is not a long.
     pub fn get_long(&self, function_builder: &mut FunctionBuilder, index: usize) -> Result<Value> {
-        self.get(function_builder, index)
+        let expected_type = types::I64;
+        let value = self.get(function_builder, index)?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Get a float from the local variables.
@@ -47,7 +63,15 @@ impl LocalVariables {
     /// # Errors
     /// if the local variable at the given index was not found or if the value is not a float.
     pub fn get_float(&self, function_builder: &mut FunctionBuilder, index: usize) -> Result<Value> {
-        self.get(function_builder, index)
+        let expected_type = types::F32;
+        let value = self.get(function_builder, index)?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Get a double from the local variables.
@@ -59,7 +83,15 @@ impl LocalVariables {
         function_builder: &mut FunctionBuilder,
         index: usize,
     ) -> Result<Value> {
-        self.get(function_builder, index)
+        let expected_type = types::F64;
+        let value = self.get(function_builder, index)?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Set a value in the local variables.
@@ -96,7 +128,14 @@ impl LocalVariables {
         index: usize,
         value: Value,
     ) -> Result<()> {
-        self.set(function_builder, index, types::I32, value)
+        let expected_type = types::I32;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.set(function_builder, index, expected_type, value)
     }
 
     /// Set a long in the local variables.
@@ -109,7 +148,14 @@ impl LocalVariables {
         index: usize,
         value: Value,
     ) -> Result<()> {
-        self.set(function_builder, index, types::I64, value)
+        let expected_type = types::I64;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.set(function_builder, index, expected_type, value)
     }
 
     /// Set a float in the local variables.
@@ -122,7 +168,14 @@ impl LocalVariables {
         index: usize,
         value: Value,
     ) -> Result<()> {
-        self.set(function_builder, index, types::F32, value)
+        let expected_type = types::F32;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.set(function_builder, index, expected_type, value)
     }
 
     /// Set a double in the local variables.
@@ -135,6 +188,13 @@ impl LocalVariables {
         index: usize,
         value: Value,
     ) -> Result<()> {
-        self.set(function_builder, index, types::F64, value)
+        let expected_type = types::F64;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.set(function_builder, index, expected_type, value)
     }
 }

--- a/ristretto_jit/src/operand_stack.rs
+++ b/ristretto_jit/src/operand_stack.rs
@@ -1,76 +1,43 @@
 use crate::Error::InternalError;
 use crate::Result;
-use cranelift::codegen::ir::{StackSlot, Value};
+use cranelift::codegen::ir::Value;
 use cranelift::frontend::FunctionBuilder;
-use cranelift::prelude::{InstBuilder, StackSlotData, StackSlotKind, Type, types};
+use cranelift::prelude::types;
 
 const POINTER_SIZE: i32 = 8;
 
 /// Operand stack for the JIT compiler.
-///
-/// The stack is implemented as a continuous array of 64bit/8byte values.  I32 and F32 values are
-/// padded to 8 bytes.  The stack is aligned to 8 bytes for performance reasons.
-///
-/// ```text
-/// |------- 8 bytes -------|----- 8 bytes -----|------- 8 bytes -------|----- 8 bytes -----|
-/// |- 4 bytes -|- 4 bytes -|                   |- 4 bytes -|- 4 bytes -|                   |
-/// |  padding  |    I32    |        I64        |  padding  |    F32    |        F64        |
-/// ```
 pub struct OperandStack {
-    slot: Option<StackSlot>,
-    length: i32,
+    stack: Vec<Value>,
 }
 
 impl OperandStack {
     /// Creates a new operand stack with the specified capacity.
-    pub fn with_capacity(function_builder: &mut FunctionBuilder, capacity: u16) -> Result<Self> {
-        // Empty methods such as e.g. Object.<init>() will have a capacity of 0. Do not create a
-        // stack slot in this case to improve performance.
-        let slot = if capacity == 0 {
-            None
-        } else {
-            let pointer_size = u32::try_from(POINTER_SIZE)?;
-            let stack_capacity = u32::from(capacity).saturating_mul(pointer_size);
-            let stack_slot_data =
-                StackSlotData::new(StackSlotKind::ExplicitSlot, stack_capacity, 0);
-            let slot = function_builder.create_sized_stack_slot(stack_slot_data);
-            Some(slot)
-        };
-        let operand_stack = OperandStack { slot, length: 0 };
-        Ok(operand_stack)
+    pub fn with_capacity(capacity: u16) -> Self {
+        OperandStack {
+            stack: Vec::with_capacity(usize::from(capacity)),
+        }
     }
 
     /// Pushes a value onto the stack.
-    fn push_type(
-        &mut self,
-        function_builder: &mut FunctionBuilder,
-        value_type: Type,
-        value: Value,
-    ) -> Result<()> {
-        let Some(slot) = self.slot else {
-            return Err(InternalError(
-                "OperandStack.slot is not initialized".to_string(),
-            ));
-        };
-        let index = self.length;
-        self.length = index + 1;
-        let slot_index = index.saturating_mul(POINTER_SIZE);
-        let value_type_bytes = value_type.bytes();
-        let padding = POINTER_SIZE.saturating_sub_unsigned(value_type_bytes);
-        let slot_index = slot_index.saturating_add(padding);
-        function_builder.ins().stack_store(value, slot, slot_index);
+    pub fn push(&mut self, value: Value) -> Result<()> {
+        if self.stack.len() >= self.stack.capacity() {
+            return Err(InternalError("OperandStack overflow".to_string()));
+        }
+        self.stack.push(value);
         Ok(())
-    }
-
-    /// Pushes a value onto the stack.
-    pub fn push(&mut self, function_builder: &mut FunctionBuilder, value: Value) -> Result<()> {
-        // Default to I64/8-bytes.
-        self.push_type(function_builder, types::I64, value)
     }
 
     /// Push an int value onto the operand stack.
     pub fn push_int(&mut self, function_builder: &mut FunctionBuilder, value: Value) -> Result<()> {
-        self.push_type(function_builder, types::I32, value)
+        let expected_type = types::I32;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.push(value)
     }
 
     /// Push a long value onto the operand stack.
@@ -79,7 +46,14 @@ impl OperandStack {
         function_builder: &mut FunctionBuilder,
         value: Value,
     ) -> Result<()> {
-        self.push_type(function_builder, types::I64, value)
+        let expected_type = types::I64;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.push(value)
     }
 
     /// Push a float value onto the operand stack.
@@ -88,7 +62,14 @@ impl OperandStack {
         function_builder: &mut FunctionBuilder,
         value: Value,
     ) -> Result<()> {
-        self.push_type(function_builder, types::F32, value)
+        let expected_type = types::F32;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.push(value)
     }
 
     /// Push a double value onto the operand stack.
@@ -97,55 +78,73 @@ impl OperandStack {
         function_builder: &mut FunctionBuilder,
         value: Value,
     ) -> Result<()> {
-        self.push_type(function_builder, types::F64, value)
+        let expected_type = types::F64;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        self.push(value)
     }
 
     /// Pops a value from the stack.
-    fn pop_type(
-        &mut self,
-        function_builder: &mut FunctionBuilder,
-        value_type: Type,
-    ) -> Result<Value> {
-        let Some(slot) = self.slot else {
-            return Err(InternalError(
-                "OperandStack.slot is not initialized".to_string(),
-            ));
+    pub fn pop(&mut self) -> Result<Value> {
+        let Some(value) = self.stack.pop() else {
+            return Err(InternalError("OperandStack underflow".to_string()));
         };
-        let index = self.length - 1;
-        let slot_index = index.saturating_mul(POINTER_SIZE);
-        let value_type_bytes = value_type.bytes();
-        let padding = POINTER_SIZE.saturating_sub_unsigned(value_type_bytes);
-        let slot_index = slot_index.saturating_add(padding);
-        let value = function_builder
-            .ins()
-            .stack_load(value_type, slot, slot_index);
-        self.length = index;
         Ok(value)
-    }
-
-    /// Pops a value from the stack.
-    pub fn pop(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        // Default to I64/8-bytes.
-        self.pop_type(function_builder, types::I64)
     }
 
     /// Pop an int from the operand stack.
     pub fn pop_int(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        self.pop_type(function_builder, types::I32)
+        let expected_type = types::I32;
+        let value = self.pop()?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Pop a long from the operand stack.
     pub fn pop_long(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        self.pop_type(function_builder, types::I64)
+        let expected_type = types::I64;
+        let value = self.pop()?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Pop a float from the operand stack.
     pub fn pop_float(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        self.pop_type(function_builder, types::F32)
+        let expected_type = types::F32;
+        let value = self.pop()?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 
     /// Pop a double from the operand stack.
     pub fn pop_double(&mut self, function_builder: &mut FunctionBuilder) -> Result<Value> {
-        self.pop_type(function_builder, types::F64)
+        let expected_type = types::F64;
+        let value = self.pop()?;
+        let value_type = function_builder.func.dfg.value_type(value);
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value)
     }
 }

--- a/ristretto_jit/tests/compile_multiply_high.rs
+++ b/ristretto_jit/tests/compile_multiply_high.rs
@@ -18,26 +18,33 @@ fn compile_multiply_high() -> Result<()> {
         attributes: Vec::new(),
     };
     let test_method_code = vec![
+        // Input arguments x: i64, y: i64
+        // x1 = x >> 32
         Instruction::Lload_0,
         Instruction::Bipush(32),
         Instruction::Lshr,
         Instruction::Lstore(4),
+        // x2 = x & 0xFFFFFFFF
         Instruction::Lload_0,
         Instruction::Ldc2_w(first_argument_index),
         Instruction::Land,
         Instruction::Lstore(6),
+        // y1 = y >> 32
         Instruction::Lload_2,
         Instruction::Bipush(32),
         Instruction::Lshr,
         Instruction::Lstore(8),
+        // y2 = y & 0xFFFFFFFF
         Instruction::Lload_2,
         Instruction::Ldc2_w(first_argument_index),
         Instruction::Land,
         Instruction::Lstore(10),
+        // z2 = x2 * y2
         Instruction::Lload(6),
         Instruction::Lload(10),
         Instruction::Lmul,
         Instruction::Lstore(12),
+        // t = x1 * y2 + (z2 >>> 32)
         Instruction::Lload(4),
         Instruction::Lload(10),
         Instruction::Lmul,
@@ -46,20 +53,24 @@ fn compile_multiply_high() -> Result<()> {
         Instruction::Lushr,
         Instruction::Ladd,
         Instruction::Lstore(14),
+        // z1 = t & 0xFFFFFFFF
         Instruction::Lload(14),
         Instruction::Ldc2_w(first_argument_index),
         Instruction::Land,
         Instruction::Lstore(16),
+        // z0 = t >> 32
         Instruction::Lload(14),
         Instruction::Bipush(32),
         Instruction::Lshr,
         Instruction::Lstore(18),
+        // z1 += x2 * y1
         Instruction::Lload(16),
         Instruction::Lload(6),
         Instruction::Lload(8),
         Instruction::Lmul,
         Instruction::Ladd,
         Instruction::Lstore(16),
+        // x1 * y1 + z0 + (z1 >> 32)
         Instruction::Lload(4),
         Instruction::Lload(8),
         Instruction::Lmul,
@@ -93,8 +104,8 @@ fn compile_multiply_high() -> Result<()> {
 
     let mut compiler = Compiler::new()?;
     let function = compiler.compile(&class_file, test_method)?;
-    let arguments = vec![Value::I64(4), Value::I64(8)];
+    let arguments = vec![Value::I64(32_767), Value::I64(9_223_372_036_854_775_807)];
     let value = function.execute(arguments)?.expect("value");
-    assert_eq!(value, Value::I64(0));
+    assert_eq!(value, Value::I64(16_383));
     Ok(())
 }

--- a/ristretto_jit/tests/return_constant.rs
+++ b/ristretto_jit/tests/return_constant.rs
@@ -1,0 +1,45 @@
+use ristretto_classfile::attributes::{Attribute, Instruction, MaxLocals, MaxStack};
+use ristretto_classfile::{ClassAccessFlags, ClassFile, ConstantPool, MethodAccessFlags};
+use ristretto_jit::{Compiler, Result, Value};
+
+#[test]
+fn compile_return_constant() -> Result<()> {
+    let mut constant_pool = ConstantPool::default();
+    let class_name_index = constant_pool.add_class("Test")?;
+    let code_index = constant_pool.add_utf8("Code")?;
+    let test_name_index = constant_pool.add_utf8("returnConstant")?;
+    let test_descriptor_index = constant_pool.add_utf8("()I")?;
+
+    let mut test_method = ristretto_classfile::Method {
+        access_flags: MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+        name_index: test_name_index,
+        descriptor_index: test_descriptor_index,
+        attributes: Vec::new(),
+    };
+    let test_method_code = vec![Instruction::Iconst_3, Instruction::Ireturn];
+    let test_max_stack = test_method_code.max_stack(&constant_pool)?;
+    let test_max_locals = test_method_code.max_locals(&constant_pool, test_descriptor_index)?;
+    test_method.attributes.push(Attribute::Code {
+        name_index: code_index,
+        max_stack: test_max_stack,
+        max_locals: test_max_locals,
+        code: test_method_code,
+        exception_table: Vec::new(),
+        attributes: Vec::new(),
+    });
+    let class_file = ClassFile {
+        constant_pool,
+        access_flags: ClassAccessFlags::PUBLIC,
+        this_class: class_name_index,
+        methods: vec![test_method],
+        attributes: Vec::new(),
+        ..Default::default()
+    };
+    let test_method = &class_file.methods[0];
+
+    let mut compiler = Compiler::new()?;
+    let function = compiler.compile(&class_file, test_method)?;
+    let value = function.execute(Vec::new())?.expect("value");
+    assert_eq!(value, Value::I32(3));
+    Ok(())
+}

--- a/ristretto_jit/tests/return_parameter.rs
+++ b/ristretto_jit/tests/return_parameter.rs
@@ -1,0 +1,46 @@
+use ristretto_classfile::attributes::{Attribute, Instruction, MaxLocals, MaxStack};
+use ristretto_classfile::{ClassAccessFlags, ClassFile, ConstantPool, MethodAccessFlags};
+use ristretto_jit::{Compiler, Result, Value};
+
+#[test]
+fn compile_return_parameter() -> Result<()> {
+    let mut constant_pool = ConstantPool::default();
+    let class_name_index = constant_pool.add_class("Test")?;
+    let code_index = constant_pool.add_utf8("Code")?;
+    let test_name_index = constant_pool.add_utf8("returnParameter")?;
+    let test_descriptor_index = constant_pool.add_utf8("(I)I")?;
+
+    let mut test_method = ristretto_classfile::Method {
+        access_flags: MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+        name_index: test_name_index,
+        descriptor_index: test_descriptor_index,
+        attributes: Vec::new(),
+    };
+    let test_method_code = vec![Instruction::Iload_0, Instruction::Ireturn];
+    let test_max_stack = test_method_code.max_stack(&constant_pool)?;
+    let test_max_locals = test_method_code.max_locals(&constant_pool, test_descriptor_index)?;
+    test_method.attributes.push(Attribute::Code {
+        name_index: code_index,
+        max_stack: test_max_stack,
+        max_locals: test_max_locals,
+        code: test_method_code,
+        exception_table: Vec::new(),
+        attributes: Vec::new(),
+    });
+    let class_file = ClassFile {
+        constant_pool,
+        access_flags: ClassAccessFlags::PUBLIC,
+        this_class: class_name_index,
+        methods: vec![test_method],
+        attributes: Vec::new(),
+        ..Default::default()
+    };
+    let test_method = &class_file.methods[0];
+
+    let mut compiler = Compiler::new()?;
+    let function = compiler.compile(&class_file, test_method)?;
+    let arguments = vec![Value::I32(42)];
+    let value = function.execute(arguments)?.expect("value");
+    assert_eq!(value, Value::I32(42));
+    Ok(())
+}


### PR DESCRIPTION
Update `OperandStack` to use registers instead of a stack slot.  Previously, a stack slot with offsets was used to store/load stack values.  With this new implementation, the current block params are intended to represent the operand stack. Example for `hashCode()`:

**Before**
```
function u0:0(i64, i64, i64) apple_aarch64 {
    ss0 = explicit_slot 24

block0(v0: i64, v1: i64, v2: i64):
    v7 = load.i64 notrap aligned v0+8
    v23 = stack_addr.i64 ss0
    store notrap v7, v23
    v24 = stack_addr.i64 ss0+8
    store notrap v7, v24
    v8 = iconst.i32 32
    v25 = stack_addr.i64 ss0+20
    store notrap v8, v25  ; v8 = 32
    v10 = load.i64 notrap v24
    v43 = iconst.i64 32
    v14 = ushr v10, v43  ; v43 = 32
    store notrap v14, v24
    v16 = load.i64 notrap v23
    v17 = bxor v16, v14
    store notrap v17, v23
    v19 = ireduce.i32 v17
    v33 = stack_addr.i64 ss0+4
    store notrap v19, v33
    v22 = iconst.i8 1
    store v22, v2  ; v22 = 1
    v21 = sextend.i64 v19
    store v21, v2+8
    return
}
```

**After**
```
function u0:0(i64, i64, i64) apple_aarch64 {
block0(v0: i64, v1: i64, v2: i64):
    v7 = load.i64 notrap aligned v0+8
    v3 = iconst.i64 16
    v10 = iadd v0, v3  ; v3 = 16
    v11 = load.i64 notrap aligned v10+8
    v51 = iconst.i8 2
    store v51, v2  ; v51 = 2
    v68 = iconst.i64 32
    v16 = sshr v7, v68  ; v68 = 32
    v23 = sshr v11, v68  ; v68 = 32
    v43 = imul v16, v23
    v17 = iconst.i64 0xffff_ffff
    v25 = band v11, v17  ; v17 = 0xffff_ffff
    v27 = imul v16, v25
    v18 = band v7, v17  ; v17 = 0xffff_ffff
    v26 = imul v18, v25
    v32 = ushr v26, v68  ; v68 = 32
    v33 = iadd v27, v32
    v40 = sshr v33, v68  ; v68 = 32
    v44 = iadd v43, v40
    v35 = band v33, v17  ; v17 = 0xffff_ffff
    v41 = imul v18, v23
    v42 = iadd v35, v41
    v49 = sshr v42, v68  ; v68 = 32
    v50 = iadd v44, v49
    store v50, v2+8
    return
}
```