### PR TITLE
feat: generate jit control flow graph using cranelift blocks

### DIFF
--- a/ristretto_jit/src/control_flow_graph/blocks.rs
+++ b/ristretto_jit/src/control_flow_graph/blocks.rs
@@ -1,0 +1,224 @@
+use crate::Error::InternalError;
+use crate::Result;
+use crate::control_flow_graph::instruction;
+use crate::control_flow_graph::type_stack::TypeStack;
+use cranelift::prelude::{Block, FunctionBuilder};
+use ristretto_classfile::ConstantPool;
+use ristretto_classfile::attributes::Instruction;
+use std::collections::HashMap;
+
+/// Creates a control flow graph of blocks for a function by analyzing the instructions.
+///
+/// # Arguments
+/// * `function_builder` - The function builder to create blocks with
+/// * `constant_pool` - The constant pool for the class
+/// * `instructions` - The Java bytecode instructions
+///
+/// # Returns
+/// A map from instruction addresses to Cranelift blocks
+///
+/// # Errors
+/// * If the address calculation overflows
+/// * If the address is not valid
+#[expect(clippy::too_many_lines)]
+pub(crate) fn get_blocks(
+    function_builder: &mut FunctionBuilder,
+    constant_pool: &ConstantPool,
+    instructions: &[Instruction],
+) -> Result<HashMap<usize, Block>> {
+    let mut blocks = HashMap::new();
+    let mut stack_states: HashMap<usize, TypeStack> = HashMap::new();
+    let mut stack = TypeStack::new();
+
+    // The first block is always the function entry point (with empty stack)
+    blocks.insert(0, function_builder.create_block());
+    stack_states.insert(0, stack.clone());
+
+    for (program_counter, instruction) in instructions.iter().enumerate() {
+        if let Some(new_stack) = stack_states.get(&program_counter) {
+            stack = new_stack.clone();
+        }
+
+        // Simulate the instruction to determine the stack state
+        instruction::simulate(&mut stack, constant_pool, instruction)?;
+
+        match instruction {
+            Instruction::Ifeq(address)
+            | Instruction::Ifne(address)
+            | Instruction::Iflt(address)
+            | Instruction::Ifge(address)
+            | Instruction::Ifgt(address)
+            | Instruction::Ifle(address)
+            | Instruction::If_icmpeq(address)
+            | Instruction::If_icmpne(address)
+            | Instruction::If_icmplt(address)
+            | Instruction::If_icmpge(address)
+            | Instruction::If_icmpgt(address)
+            | Instruction::If_icmple(address) => {
+                let then_address = usize::from(*address);
+                insert_stack(&mut stack_states, then_address, &stack)?;
+                create_block_with_parameters(
+                    function_builder,
+                    &stack_states,
+                    then_address,
+                    &mut blocks,
+                );
+
+                let Some(else_address) = program_counter.checked_add(1) else {
+                    return Err(InternalError(format!(
+                        "Address overflow: {program_counter} + 1"
+                    )));
+                };
+                insert_stack(&mut stack_states, else_address, &stack)?;
+                create_block_with_parameters(
+                    function_builder,
+                    &stack_states,
+                    else_address,
+                    &mut blocks,
+                );
+            }
+            Instruction::Goto(address) | Instruction::Jsr(address) => {
+                let address = usize::from(*address);
+                insert_stack(&mut stack_states, address, &stack)?;
+                create_block_with_parameters(function_builder, &stack_states, address, &mut blocks);
+            }
+            Instruction::Goto_w(address) | Instruction::Jsr_w(address) => {
+                let address = usize::try_from(*address)?;
+                insert_stack(&mut stack_states, address, &stack)?;
+                create_block_with_parameters(function_builder, &stack_states, address, &mut blocks);
+            }
+            Instruction::Tableswitch {
+                default, offsets, ..
+            } => {
+                let default = usize::try_from(*default)?;
+                let default = program_counter.checked_add(default).ok_or_else(|| {
+                    InternalError(format!(
+                        "Invalid address calculation: {program_counter} + {default}"
+                    ))
+                })?;
+                insert_stack(&mut stack_states, default, &stack)?;
+                create_block_with_parameters(function_builder, &stack_states, default, &mut blocks);
+
+                for offset in offsets {
+                    let address = usize::try_from(*offset)?;
+                    let address = program_counter.checked_add(address).ok_or_else(|| {
+                        InternalError(format!(
+                            "Invalid address calculation: {program_counter} + {address}"
+                        ))
+                    })?;
+                    insert_stack(&mut stack_states, address, &stack)?;
+                    create_block_with_parameters(
+                        function_builder,
+                        &stack_states,
+                        address,
+                        &mut blocks,
+                    );
+                }
+            }
+            Instruction::Lookupswitch { default, pairs } => {
+                let default = usize::try_from(*default)?;
+                let default = program_counter.checked_add(default).ok_or_else(|| {
+                    InternalError(format!(
+                        "Invalid address calculation: {program_counter} + {default}"
+                    ))
+                })?;
+                insert_stack(&mut stack_states, default, &stack)?;
+                create_block_with_parameters(function_builder, &stack_states, default, &mut blocks);
+
+                for (_key, offset) in pairs {
+                    let address = usize::try_from(*offset)?;
+                    let address = program_counter.checked_add(address).ok_or_else(|| {
+                        InternalError(format!(
+                            "Invalid address calculation: {program_counter} + {address}"
+                        ))
+                    })?;
+                    insert_stack(&mut stack_states, address, &stack)?;
+                    create_block_with_parameters(
+                        function_builder,
+                        &stack_states,
+                        address,
+                        &mut blocks,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(blocks)
+}
+
+/// Inserts stack for address
+pub fn insert_stack(
+    stack_states: &mut HashMap<usize, TypeStack>,
+    address: usize,
+    stack: &TypeStack,
+) -> Result<()> {
+    match stack_states.get(&address) {
+        Some(entry_stack) => {
+            if entry_stack != stack {
+                return Err(InternalError(format!(
+                    "Invalid stack state for address {address}, entry_stack={entry_stack:?} and stack={stack:?}"
+                )));
+            }
+        }
+        None => {
+            stack_states.insert(address, stack.clone());
+        }
+    }
+    Ok(())
+}
+
+/// Utility function to create a block with parameters matching the expected stack state
+fn create_block_with_parameters(
+    function_builder: &mut FunctionBuilder,
+    stack_states: &HashMap<usize, TypeStack>,
+    address: usize,
+    blocks: &mut HashMap<usize, Block>,
+) {
+    blocks.entry(address).or_insert_with(|| {
+        let block = function_builder.create_block();
+
+        if let Some(stack_types) = stack_states.get(&address) {
+            let stack_types = stack_types.to_vec();
+            for value_type in stack_types {
+                function_builder.append_block_param(block, value_type);
+            }
+        }
+
+        block
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cranelift::codegen::ir::Function;
+    use cranelift::prelude::*;
+
+    #[test]
+    fn test_blocks_for_if_comparison_with_goto() -> Result<()> {
+        let constant_pool = ConstantPool::new();
+        let mut function_context = FunctionBuilderContext::new();
+        let mut function = Function::new();
+        let mut function_builder = FunctionBuilder::new(&mut function, &mut function_context);
+        let instructions = vec![
+            Instruction::Iload_0,      // 0: Load local variable 0
+            Instruction::Iload_1,      // 1: Load local variable 1
+            Instruction::If_icmplt(5), // 2: If var0 < var1, branch to instruction 5
+            Instruction::Iload_0,      // 3: Load local variable 0
+            Instruction::Goto(6),      // 4: Jump to instruction 6
+            Instruction::Iload_1,      // 5: Load local variable 1
+            Instruction::Ireturn,      // 6: Return value on stack
+        ];
+
+        // Create the control_flow_graph
+        let blocks = get_blocks(&mut function_builder, &constant_pool, &instructions)?;
+        assert_eq!(blocks.len(), 4);
+        let _block_0 = blocks.get(&0).expect("block0");
+        let _block_3 = blocks.get(&3).expect("block3");
+        let _block_5 = blocks.get(&5).expect("block5");
+        let _block_6 = blocks.get(&6).expect("block6");
+        Ok(())
+    }
+}

--- a/ristretto_jit/src/control_flow_graph/instruction.rs
+++ b/ristretto_jit/src/control_flow_graph/instruction.rs
@@ -1,0 +1,614 @@
+use crate::Error::{InvalidConstant, InvalidConstantIndex};
+use crate::Result;
+use crate::control_flow_graph::type_stack::TypeStack;
+use cranelift::prelude::{Type, types};
+use ristretto_classfile::attributes::Instruction;
+use ristretto_classfile::{BaseType, Constant, ConstantPool, FieldType};
+
+/// Simulates the effect of an instruction on the stack.
+#[expect(clippy::too_many_lines)]
+pub(crate) fn simulate(
+    stack: &mut TypeStack,
+    constant_pool: &ConstantPool,
+    instruction: &Instruction,
+) -> Result<()> {
+    match instruction {
+        Instruction::Nop
+        | Instruction::Iinc(..)
+        | Instruction::Iinc_w(..)
+        | Instruction::Goto(..)
+        | Instruction::Goto_w(..)
+        | Instruction::Ret(..)
+        | Instruction::Ret_w(..)
+        | Instruction::Return
+        | Instruction::Wide
+        | Instruction::Breakpoint
+        | Instruction::Impdep1
+        | Instruction::Impdep2 => {}
+        Instruction::Aconst_null => stack.push_object()?,
+        Instruction::Iconst_m1
+        | Instruction::Iconst_0
+        | Instruction::Iconst_1
+        | Instruction::Iconst_2
+        | Instruction::Iconst_3
+        | Instruction::Iconst_4
+        | Instruction::Iconst_5 => stack.push_int()?,
+        Instruction::Lconst_0 | Instruction::Lconst_1 => stack.push_long()?,
+        Instruction::Fconst_0 | Instruction::Fconst_1 | Instruction::Fconst_2 => {
+            stack.push_float()?;
+        }
+        Instruction::Dconst_0 | Instruction::Dconst_1 => stack.push_double()?,
+        Instruction::Bipush(..) | Instruction::Sipush(..) => stack.push_int()?,
+        Instruction::Ldc(index) => ldc(stack, constant_pool, u16::from(*index))?,
+        Instruction::Ldc_w(index) => ldc(stack, constant_pool, *index)?,
+        Instruction::Ldc2_w(index) => {
+            let constant = constant_pool
+                .get(*index)
+                .ok_or_else(|| InvalidConstantIndex(*index))?;
+
+            match constant {
+                Constant::Long(_) => stack.push_long()?,
+                Constant::Double(_) => stack.push_double()?,
+                constant => {
+                    return Err(InvalidConstant {
+                        expected: "long|double".to_string(),
+                        actual: format!("{constant:?}"),
+                    });
+                }
+            }
+        }
+        Instruction::Iload(..) | Instruction::Iload_w(..) => stack.push_int()?,
+        Instruction::Lload(..) | Instruction::Lload_w(..) => stack.push_long()?,
+        Instruction::Fload(..) | Instruction::Fload_w(..) => stack.push_float()?,
+        Instruction::Dload(..) | Instruction::Dload_w(..) => stack.push_double()?,
+        Instruction::Aload(..) | Instruction::Aload_w(..) => stack.push_object()?,
+        Instruction::Iload_0
+        | Instruction::Iload_1
+        | Instruction::Iload_2
+        | Instruction::Iload_3 => stack.push_int()?,
+        Instruction::Lload_0
+        | Instruction::Lload_1
+        | Instruction::Lload_2
+        | Instruction::Lload_3 => stack.push_long()?,
+        Instruction::Fload_0
+        | Instruction::Fload_1
+        | Instruction::Fload_2
+        | Instruction::Fload_3 => stack.push_float()?,
+        Instruction::Dload_0
+        | Instruction::Dload_1
+        | Instruction::Dload_2
+        | Instruction::Dload_3 => stack.push_double()?,
+        Instruction::Aload_0
+        | Instruction::Aload_1
+        | Instruction::Aload_2
+        | Instruction::Aload_3 => stack.push_object()?,
+        Instruction::Iaload => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+            stack.push_int()?;
+        }
+        Instruction::Laload => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+            stack.push_long()?;
+        }
+        Instruction::Faload => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+            stack.push_float()?;
+        }
+        Instruction::Daload => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+            stack.push_double()?;
+        }
+        Instruction::Aaload => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+            stack.push_object()?;
+        }
+        Instruction::Baload | Instruction::Caload | Instruction::Saload => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+            stack.push_int()?;
+        }
+        Instruction::Istore(..) | Instruction::Istore_w(..) => {
+            let _ = stack.pop_int()?;
+        }
+        Instruction::Lstore(..) | Instruction::Lstore_w(..) => {
+            let _ = stack.pop_long()?;
+        }
+        Instruction::Fstore(..) | Instruction::Fstore_w(..) => {
+            let _ = stack.pop_float()?;
+        }
+        Instruction::Dstore(..) | Instruction::Dstore_w(..) => {
+            let _ = stack.pop_double()?;
+        }
+        Instruction::Astore(..) | Instruction::Astore_w(..) => {
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Istore_0
+        | Instruction::Istore_1
+        | Instruction::Istore_2
+        | Instruction::Istore_3 => {
+            let _ = stack.pop_int()?;
+        }
+        Instruction::Lstore_0
+        | Instruction::Lstore_1
+        | Instruction::Lstore_2
+        | Instruction::Lstore_3 => {
+            let _ = stack.pop_long()?;
+        }
+        Instruction::Fstore_0
+        | Instruction::Fstore_1
+        | Instruction::Fstore_2
+        | Instruction::Fstore_3 => {
+            let _ = stack.pop_float()?;
+        }
+        Instruction::Dstore_0
+        | Instruction::Dstore_1
+        | Instruction::Dstore_2
+        | Instruction::Dstore_3 => {
+            let _ = stack.pop_double()?;
+        }
+        Instruction::Astore_0
+        | Instruction::Astore_1
+        | Instruction::Astore_2
+        | Instruction::Astore_3 => {
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Iastore => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Lastore => {
+            let _ = stack.pop_long()?;
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Fastore => {
+            let _ = stack.pop_float()?;
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Dastore => {
+            let _ = stack.pop_double()?;
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Aastore => {
+            let _ = stack.pop_object()?;
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Bastore | Instruction::Castore | Instruction::Sastore => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Pop => {
+            let _ = stack.pop()?;
+        }
+        Instruction::Pop2 => {
+            let value_type = stack.pop()?;
+            if is_category_1(value_type) {
+                let _ = stack.pop()?;
+            }
+        }
+        Instruction::Dup => {
+            let value = stack.pop()?;
+            stack.push(value)?;
+            stack.push(value)?;
+        }
+        Instruction::Dup_x1 => {
+            let value1 = stack.pop()?;
+            let value2 = stack.pop()?;
+            stack.push(value1)?;
+            stack.push(value2)?;
+            stack.push(value1)?;
+        }
+        Instruction::Dup_x2 => {
+            let value1 = stack.pop()?;
+            let value2 = stack.pop()?;
+            if is_category_1(value2) {
+                let value3 = stack.pop()?;
+                stack.push(value1)?;
+                stack.push(value3)?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+            } else {
+                stack.push(value1)?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+            }
+        }
+        Instruction::Dup2 => {
+            let value1 = stack.pop()?;
+            if is_category_1(value1) {
+                let value2 = stack.pop()?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+            } else {
+                stack.push(value1)?;
+                stack.push(value1)?;
+            }
+        }
+        Instruction::Dup2_x1 => {
+            let value1 = stack.pop()?;
+            let value2 = stack.pop()?;
+            if is_category_1(value1) {
+                let value3 = stack.pop()?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+                stack.push(value3)?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+            } else {
+                stack.push(value1)?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+            }
+        }
+        Instruction::Dup2_x2 => {
+            let value1 = stack.pop()?;
+            let value2 = stack.pop()?;
+            if is_category_1(value1) {
+                let value3 = stack.pop()?;
+                if is_category_1(value3) {
+                    let value4 = stack.pop()?;
+                    stack.push(value2)?;
+                    stack.push(value1)?;
+                    stack.push(value4)?;
+                } else {
+                    stack.push(value1)?;
+                }
+                stack.push(value3)?;
+                stack.push(value2)?;
+                stack.push(value1)?;
+            } else {
+                if is_category_1(value2) {
+                    let value3 = stack.pop()?;
+                    stack.push(value1)?;
+                    stack.push(value3)?;
+                } else {
+                    stack.push(value1)?;
+                }
+                stack.push(value2)?;
+                stack.push(value1)?;
+            }
+        }
+        Instruction::Swap => {
+            let value1 = stack.pop()?;
+            let value2 = stack.pop()?;
+            stack.push(value1)?;
+            stack.push(value2)?;
+        }
+        Instruction::Iadd
+        | Instruction::Isub
+        | Instruction::Imul
+        | Instruction::Idiv
+        | Instruction::Irem => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_int()?;
+            stack.push_int()?;
+        }
+        Instruction::Ladd
+        | Instruction::Lsub
+        | Instruction::Lmul
+        | Instruction::Ldiv
+        | Instruction::Lrem => {
+            let _ = stack.pop_long()?;
+            let _ = stack.pop_long()?;
+            stack.push_long()?;
+        }
+        Instruction::Fadd
+        | Instruction::Fsub
+        | Instruction::Fmul
+        | Instruction::Fdiv
+        | Instruction::Frem => {
+            let _ = stack.pop_float()?;
+            let _ = stack.pop_float()?;
+            stack.push_float()?;
+        }
+        Instruction::Dadd
+        | Instruction::Dsub
+        | Instruction::Dmul
+        | Instruction::Ddiv
+        | Instruction::Drem => {
+            let _ = stack.pop_double()?;
+            let _ = stack.pop_double()?;
+            stack.push_double()?;
+        }
+        Instruction::Ineg => {
+            let _ = stack.pop_int()?;
+            stack.push_int()?;
+        }
+        Instruction::Lneg => {
+            let _ = stack.pop_long()?;
+            stack.push_long()?;
+        }
+        Instruction::Fneg => {
+            let _ = stack.pop_float()?;
+            stack.push_float()?;
+        }
+        Instruction::Dneg => {
+            let _ = stack.pop_double()?;
+            stack.push_double()?;
+        }
+        Instruction::Ishl
+        | Instruction::Ishr
+        | Instruction::Iushr
+        | Instruction::Iand
+        | Instruction::Ior
+        | Instruction::Ixor => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_int()?;
+            stack.push_int()?;
+        }
+        Instruction::Lshl | Instruction::Lshr | Instruction::Lushr => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_long()?;
+            stack.push_long()?;
+        }
+        Instruction::Land | Instruction::Lor | Instruction::Lxor => {
+            let _ = stack.pop_long()?;
+            let _ = stack.pop_long()?;
+            stack.push_long()?;
+        }
+        Instruction::I2l => {
+            let _ = stack.pop_int()?;
+            stack.push_long()?;
+        }
+        Instruction::I2f => {
+            let _ = stack.pop_int()?;
+            stack.push_float()?;
+        }
+        Instruction::I2d => {
+            let _ = stack.pop_int()?;
+            stack.push_double()?;
+        }
+        Instruction::L2i => {
+            let _ = stack.pop_long()?;
+            stack.push_int()?;
+        }
+        Instruction::L2f => {
+            let _ = stack.pop_long()?;
+            stack.push_float()?;
+        }
+        Instruction::L2d => {
+            let _ = stack.pop_long()?;
+            stack.push_double()?;
+        }
+        Instruction::F2i => {
+            let _ = stack.pop_float()?;
+            stack.push_int()?;
+        }
+        Instruction::F2l => {
+            let _ = stack.pop_float()?;
+            stack.push_long()?;
+        }
+        Instruction::F2d => {
+            let _ = stack.pop_float()?;
+            stack.push_double()?;
+        }
+        Instruction::D2i => {
+            let _ = stack.pop_double()?;
+            stack.push_int()?;
+        }
+        Instruction::D2l => {
+            let _ = stack.pop_double()?;
+            stack.push_long()?;
+        }
+        Instruction::D2f => {
+            let _ = stack.pop_double()?;
+            stack.push_float()?;
+        }
+        Instruction::I2b | Instruction::I2c | Instruction::I2s => {
+            let _ = stack.pop_int()?;
+            stack.push_int()?;
+        }
+        Instruction::Lcmp => {
+            let _ = stack.pop_long()?;
+            let _ = stack.pop_long()?;
+            stack.push_int()?;
+        }
+        Instruction::Fcmpl | Instruction::Fcmpg => {
+            let _ = stack.pop_float()?;
+            let _ = stack.pop_float()?;
+            stack.push_int()?;
+        }
+        Instruction::Dcmpl | Instruction::Dcmpg => {
+            let _ = stack.pop_double()?;
+            let _ = stack.pop_double()?;
+            stack.push_int()?;
+        }
+        Instruction::Ifeq(..)
+        | Instruction::Ifne(..)
+        | Instruction::Iflt(..)
+        | Instruction::Ifge(..)
+        | Instruction::Ifgt(..)
+        | Instruction::Ifle(..) => {
+            let _ = stack.pop_int()?;
+        }
+        Instruction::If_icmpeq(..)
+        | Instruction::If_icmpne(..)
+        | Instruction::If_icmplt(..)
+        | Instruction::If_icmpge(..)
+        | Instruction::If_icmpgt(..)
+        | Instruction::If_icmple(..) => {
+            let _ = stack.pop_int()?;
+            let _ = stack.pop_int()?;
+        }
+        Instruction::If_acmpeq(..) | Instruction::If_acmpne(..) => {
+            let _ = stack.pop_object()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Jsr(..) | Instruction::Jsr_w(..) => stack.push_int()?,
+        Instruction::Tableswitch { .. } | Instruction::Lookupswitch { .. } => {
+            let _ = stack.pop_int()?;
+        }
+        Instruction::Ireturn => {
+            let _ = stack.pop_int()?;
+        }
+        Instruction::Lreturn => {
+            let _ = stack.pop_long()?;
+        }
+        Instruction::Freturn => {
+            let _ = stack.pop_float()?;
+        }
+        Instruction::Dreturn => {
+            let _ = stack.pop_double()?;
+        }
+        Instruction::Areturn => {
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Getstatic(..) => stack.push_object()?,
+        Instruction::Putstatic(..) => {
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Getfield(..) => {
+            let _ = stack.pop_object()?;
+            stack.push_object()?;
+        }
+        Instruction::Putfield(..) => {
+            let _ = stack.pop_object()?;
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Invokevirtual(method_index)
+        | Instruction::Invokespecial(method_index)
+        | Instruction::Invokestatic(method_index)
+        | Instruction::Invokeinterface(method_index, ..)
+        | Instruction::Invokedynamic(method_index) => {
+            let (_class_index, name_and_type_index) =
+                constant_pool.try_get_method_ref(*method_index)?;
+            let (_name_index, descriptor_index) =
+                constant_pool.try_get_name_and_type(*name_and_type_index)?;
+            let method_descriptor = constant_pool.try_get_utf8(*descriptor_index)?;
+
+            if !matches!(instruction, Instruction::Invokespecial(..))
+                && !matches!(instruction, Instruction::Invokestatic(..))
+            {
+                let _ = stack.pop_object()?;
+            }
+
+            let (parameters, return_type) = FieldType::parse_method_descriptor(method_descriptor)?;
+            for parameter in parameters {
+                match parameter {
+                    FieldType::Base(
+                        BaseType::Boolean
+                        | BaseType::Byte
+                        | BaseType::Char
+                        | BaseType::Int
+                        | BaseType::Short,
+                    ) => {
+                        let _ = stack.pop_int()?;
+                    }
+                    FieldType::Base(BaseType::Long) => {
+                        let _ = stack.pop_long()?;
+                    }
+                    FieldType::Base(BaseType::Float) => {
+                        let _ = stack.pop_float()?;
+                    }
+                    FieldType::Base(BaseType::Double) => {
+                        let _ = stack.pop_double()?;
+                    }
+                    FieldType::Object(_) | FieldType::Array(_) => {
+                        let _ = stack.pop_object()?;
+                    }
+                }
+            }
+
+            if let Some(return_type) = return_type {
+                match return_type {
+                    FieldType::Base(
+                        BaseType::Boolean
+                        | BaseType::Byte
+                        | BaseType::Char
+                        | BaseType::Int
+                        | BaseType::Short,
+                    ) => {
+                        stack.push_int()?;
+                    }
+                    FieldType::Base(BaseType::Long) => {
+                        stack.push_long()?;
+                    }
+                    FieldType::Base(BaseType::Float) => {
+                        stack.push_float()?;
+                    }
+                    FieldType::Base(BaseType::Double) => {
+                        stack.push_double()?;
+                    }
+                    FieldType::Object(_) | FieldType::Array(_) => {
+                        stack.push_object()?;
+                    }
+                }
+            }
+        }
+        Instruction::New(..) => {
+            stack.push_object()?;
+        }
+        Instruction::Newarray(..) | Instruction::Anewarray(..) => {
+            let _ = stack.pop_int()?;
+            stack.push_object()?;
+        }
+        Instruction::Arraylength => {
+            let _ = stack.pop_object()?;
+            stack.push_int()?;
+        }
+        Instruction::Athrow => {
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Checkcast(..) => {
+            let _ = stack.pop_object()?;
+            stack.push_object()?;
+        }
+        Instruction::Instanceof(..) => {
+            let _ = stack.pop_object()?;
+            stack.push_int()?;
+        }
+        Instruction::Monitorenter | Instruction::Monitorexit => {
+            let _ = stack.pop_object()?;
+        }
+        Instruction::Multianewarray(dimensions, ..) => {
+            let _ = stack.pop_int()?;
+            for _ in 1..*dimensions {
+                let _ = stack.pop_int()?;
+            }
+            stack.push_object()?;
+        }
+        Instruction::Ifnull(..) | Instruction::Ifnonnull(..) => {
+            let _ = stack.pop_object()?;
+        }
+    }
+    Ok(())
+}
+
+/// Loads a constant from the constant pool and pushes the type onto the stack.
+fn ldc(stack: &mut TypeStack, constant_pool: &ConstantPool, index: u16) -> Result<()> {
+    let constant = constant_pool
+        .get(index)
+        .ok_or_else(|| InvalidConstantIndex(index))?;
+
+    match constant {
+        Constant::Integer(_) => stack.push_int(),
+        Constant::Float(_) => stack.push_float(),
+        Constant::String(_) | Constant::Class(_) => stack.push_object(),
+        constant => Err(InvalidConstant {
+            expected: "integer|float|string|class".to_string(),
+            actual: format!("{constant:?}"),
+        }),
+    }
+}
+
+/// Returns true if the type is a category 1 type.
+fn is_category_1(value_type: Type) -> bool {
+    is_category_2(value_type)
+}
+
+/// Returns true if the type is a category 2 type.
+fn is_category_2(value_type: Type) -> bool {
+    value_type == types::I64 || value_type == types::F64
+}

--- a/ristretto_jit/src/control_flow_graph/mod.rs
+++ b/ristretto_jit/src/control_flow_graph/mod.rs
@@ -1,0 +1,68 @@
+/// This module creates a Control Flow Graph (CFG) for Java byte code using Cranelift
+/// [Block](https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/entities/struct.Block.html)
+/// structures.  The Java stack is transformed into `Block` arguments with Static Single Assignment
+/// (SSA) [Values](https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/entities/struct.Value.html)
+/// passed as parameters to blocks with branching operations (e.g. `jump`, `brif`, etc)
+///
+/// Java byte code for `Integer.max(II)I`:
+/// ```rust
+/// use ristretto_classfile::attributes::Instruction;
+///
+/// let instructions = vec![
+///    Instruction::Iload_0,      // 0: Load local variable 0
+///    Instruction::Iload_1,      // 1: Load local variable 1
+///    Instruction::If_icmplt(5), // 2: If var0 < var1, branch to instruction 5
+///    Instruction::Iload_0,      // 3: Load local variable 0
+///    Instruction::Goto(6),      // 4: Jump to instruction 6
+///    Instruction::Iload_1,      // 5: Load local variable 1
+///    Instruction::Ireturn,      // 6: Return value on stack
+/// ];
+/// ```
+///
+/// Control flow graph diagram for `Integer.max(II)I` transformed into Cranelift blocks where the
+/// stack state is managed using SSA by defining arguments on blocks and passing parameters:
+/// ```text
+///                         +------------------------------------------------------------+
+///                         |                         block0 ()                          |
+///                         |  // entry point with 2 local variables (l0: i32, l1: i32)  |
+///                         |                                                            |
+///                         |  ; Java 0: Iload_0                                         |
+///                         |  v0 = load.i32 notrap aligned l0              stack: [v0]  |
+///                         |                                                            |
+///                         |  ; Java 1: Iload_1                                         |
+///                         |  v1 = load.i32 notrap aligned l1          stack: [v0, v1]  |
+///                         |                                                            |
+///                         |  ; Java 2: If_icmplt(5)                                    |
+///                         |  v2 = icmp_lt slt v0, v1                        stack: []  |
+///                         |  brif v2, block1, block2                        stack: []  |
+///                         +------------------------------------------------------------+
+///                                           /                        \
+///                                     (cond == 1)                (cond == 0)
+///                                         /                            \
+///  +--------------------------------------------------+    +--------------------------------------------------+
+///  |                    block1 ()                     |    |                    block2 ()                     |
+///  |  // target of Java If_icmplt(5)                  |    |  // fall-through path to instructions 3 & 4      |
+///  |                                                  |    |                                                  |
+///  |  ; Java 5: Iload_1                               |    |  ; Java 3: Iload_0                               |
+///  |  v3 = load.i32 notrap aligned l1    stack: [v3]  |    |  v4 = load.i32 notrap aligned l0    stack: [v4]  |
+///  |                                                  |    |                                                  |
+///  |  jump block3(v3)                    stack: [v3]  |    |  ; Java 4: Goto 6                                |
+///  +--------------------------------------------------+    |  jump block3(v4)                    stack: [v4]  |
+///                                         \                +--------------------------------------------------+
+///                                          \                           /
+///                                           \                         /
+///                                            \                       /
+///                                             v                     v
+///                              +--------------------------------------------------+
+///                              |             block3 (p0: i32)                     |
+///                              |  // join point with 1 incoming i32 param         |
+///                              |  v5 = load.i32 notrap aligned p0    stack: [v5]  |
+///                              |                                                  |
+///                              |  ; Java 6: Ireturn                               |
+///                              |  return v5                            stack: []  |
+///                              +--------------------------------------------------+
+/// ```
+///
+mod blocks;
+mod instruction;
+mod type_stack;

--- a/ristretto_jit/src/control_flow_graph/type_stack.rs
+++ b/ristretto_jit/src/control_flow_graph/type_stack.rs
@@ -1,0 +1,273 @@
+use crate::Error::InternalError;
+use crate::Result;
+use cranelift::prelude::{Type, types};
+
+const POINTER_SIZE: i32 = 8;
+
+/// Type stack for determining block parameters when simulating stack operations.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TypeStack {
+    stack: Vec<Type>,
+}
+
+impl TypeStack {
+    /// Creates a new type stack with the specified capacity.
+    pub fn new() -> Self {
+        TypeStack { stack: Vec::new() }
+    }
+
+    /// Pushes a value onto the stack.
+    #[expect(clippy::unnecessary_wraps)]
+    pub fn push(&mut self, value_type: Type) -> Result<()> {
+        self.stack.push(value_type);
+        Ok(())
+    }
+
+    /// Push an int type onto the stack.
+    pub fn push_int(&mut self) -> Result<()> {
+        self.push(types::I32)
+    }
+
+    /// Push a long type onto the stack.
+    pub fn push_long(&mut self) -> Result<()> {
+        self.push(types::I64)
+    }
+
+    /// Push a float type onto the stack.
+    pub fn push_float(&mut self) -> Result<()> {
+        self.push(types::F32)
+    }
+
+    /// Push a double type onto the stack.
+    pub fn push_double(&mut self) -> Result<()> {
+        self.push(types::F64)
+    }
+
+    /// Push a double type onto the stack.
+    pub fn push_object(&mut self) -> Result<()> {
+        self.push(types::I64)
+    }
+
+    /// Pops a type from the stack.
+    pub fn pop(&mut self) -> Result<Type> {
+        let Some(value) = self.stack.pop() else {
+            return Err(InternalError("TypeStack underflow".to_string()));
+        };
+        Ok(value)
+    }
+
+    /// Pop an int from the stack.
+    pub fn pop_int(&mut self) -> Result<Type> {
+        let expected_type = types::I32;
+        let value_type = self.pop()?;
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value_type)
+    }
+
+    /// Pop a long from the stack.
+    pub fn pop_long(&mut self) -> Result<Type> {
+        let expected_type = types::I64;
+        let value_type = self.pop()?;
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value_type)
+    }
+
+    /// Pop a float from the stack.
+    pub fn pop_float(&mut self) -> Result<Type> {
+        let expected_type = types::F32;
+        let value_type = self.pop()?;
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value_type)
+    }
+
+    /// Pop a double from the stack.
+    pub fn pop_double(&mut self) -> Result<Type> {
+        let expected_type = types::F64;
+        let value_type = self.pop()?;
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value_type)
+    }
+
+    /// Pop a object from the stack.
+    pub fn pop_object(&mut self) -> Result<Type> {
+        let expected_type = types::I64;
+        let value_type = self.pop()?;
+        if value_type != expected_type {
+            return Err(InternalError(format!(
+                "Expected {expected_type:?}, found {value_type:?}",
+            )));
+        }
+        Ok(value_type)
+    }
+
+    /// Returns the length of the stack.
+    pub fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Clears the stack.
+    pub fn clear(&mut self) {
+        self.stack.clear();
+    }
+
+    /// Returns stack as a vector.
+    pub fn to_vec(&self) -> Vec<Type> {
+        self.stack.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_type_stack_all_types() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_int()?;
+        type_stack.push_long()?;
+        type_stack.push_float()?;
+        type_stack.push_double()?;
+        type_stack.push_object()?;
+
+        assert_eq!(type_stack.stack.len(), 5);
+        assert_eq!(type_stack.pop_object()?, types::I64);
+        assert_eq!(type_stack.pop_double()?, types::F64);
+        assert_eq!(type_stack.pop_float()?, types::F32);
+        assert_eq!(type_stack.pop_long()?, types::I64);
+        assert_eq!(type_stack.pop_int()?, types::I32);
+        Ok(())
+    }
+
+    #[test]
+    fn test_push_and_pop() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push(types::I32)?;
+
+        let value_type = type_stack.pop()?;
+        assert_eq!(value_type, types::I32);
+        assert!(type_stack.pop().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_push_int_and_pop_int() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_int()?;
+
+        let value_type = type_stack.pop_int()?;
+        assert_eq!(value_type, types::I32);
+        assert!(type_stack.pop_int().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_pop_int_error() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_long()?;
+        assert!(type_stack.pop_int().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_push_long_and_pop_long() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_long()?;
+
+        let value_type = type_stack.pop_long()?;
+        assert_eq!(value_type, types::I64);
+        assert!(type_stack.pop_long().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_pop_long_error() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_int()?;
+        assert!(type_stack.pop_long().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_push_float_and_pop_float() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_float()?;
+
+        let value_type = type_stack.pop_float()?;
+        assert_eq!(value_type, types::F32);
+        assert!(type_stack.pop_float().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_pop_float_error() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_long()?;
+        assert!(type_stack.pop_float().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_push_double_and_pop_double() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_double()?;
+
+        let value_type = type_stack.pop_double()?;
+        assert_eq!(value_type, types::F64);
+        assert!(type_stack.pop_double().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_pop_double_error() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_long()?;
+        assert!(type_stack.pop_double().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_push_object_and_pop_object() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_object()?;
+
+        let value_type = type_stack.pop_object()?;
+        assert_eq!(value_type, types::I64);
+        assert!(type_stack.pop_object().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_pop_object_error() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_int()?;
+        assert!(type_stack.pop_object().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_vec() -> Result<()> {
+        let mut type_stack = TypeStack::new();
+        type_stack.push_int()?;
+        type_stack.push_long()?;
+
+        let types = type_stack.to_vec();
+        assert_eq!(types, vec![types::I32, types::I64]);
+        Ok(())
+    }
+}

--- a/ristretto_jit/src/lib.rs
+++ b/ristretto_jit/src/lib.rs
@@ -18,6 +18,7 @@
 
 #[cfg(not(target_family = "wasm"))]
 mod compiler;
+mod control_flow_graph;
 mod error;
 mod function;
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
Create a Control Flow Graph (CFG) for Java byte code using Cranelift [Block](https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/entities/struct.Block.html) structures.  The Java stack is transformed into `Block` arguments with Static Single Assignment (SSA) [Values](https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/entities/struct.Value.html) passed as parameters to blocks with branching operations (e.g. `jump`, `brif`, etc)

Java byte code for `Integer.max(II)I`:
```rust
use ristretto_classfile::attributes::Instruction;

let instructions = vec![
   Instruction::Iload_0,      // 0: Load local variable 0
   Instruction::Iload_1,      // 1: Load local variable 1
   Instruction::If_icmplt(5), // 2: If var0 < var1, branch to instruction 5
   Instruction::Iload_0,      // 3: Load local variable 0
   Instruction::Goto(6),      // 4: Jump to instruction 6
   Instruction::Iload_1,      // 5: Load local variable 1
   Instruction::Ireturn,      // 6: Return value on stack
];
```

Control flow graph diagram for `Integer.max(II)I` transformed into Cranelift blocks where the
stack state is managed using SSA by defining arguments on blocks and passing parameters:
```text
                        +------------------------------------------------------------+
                        |                         block0 ()                          |
                        |  // entry point with 2 local variables (l0: i32, l1: i32)  |
                        |                                                            |
                        |  ; Java 0: Iload_0                                         |
                        |  v0 = load.i32 notrap aligned l0              stack: [v0]  |
                        |                                                            |
                        |  ; Java 1: Iload_1                                         |
                        |  v1 = load.i32 notrap aligned l1          stack: [v0, v1]  |
                        |                                                            |
                        |  ; Java 2: If_icmplt(5)                                    |
                        |  v2 = icmp_lt slt v0, v1                        stack: []  |
                        |  brif v2, block1, block2                        stack: []  |
                        +------------------------------------------------------------+
                                          /                        \
                                    (cond == 1)                (cond == 0)
                                        /                            \
 +--------------------------------------------------+    +--------------------------------------------------+
 |                    block1 ()                     |    |                    block2 ()                     |
 |  // target of Java If_icmplt(5)                  |    |  // fall-through path to instructions 3 & 4      |
 |                                                  |    |                                                  |
 |  ; Java 5: Iload_1                               |    |  ; Java 3: Iload_0                               |
 |  v3 = load.i32 notrap aligned l1    stack: [v3]  |    |  v4 = load.i32 notrap aligned l0    stack: [v4]  |
 |                                                  |    |                                                  |
 |  jump block3(v3)                    stack: [v3]  |    |  ; Java 4: Goto 6                                |
 +--------------------------------------------------+    |  jump block3(v4)                    stack: [v4]  |
                                        \                +--------------------------------------------------+
                                         \                           /
                                          \                         /
                                           \                       /
                                            v                     v
                             +--------------------------------------------------+
                             |             block3 (p0: i32)                     |
                             |  // join point with 1 incoming i32 param         |
                             |  v5 = load.i32 notrap aligned p0    stack: [v5]  |
                             |                                                  |
                             |  ; Java 6: Ireturn                               |
                             |  return v5                            stack: []  |
                             +--------------------------------------------------+
```