### PR TITLE
refactor!: optimize Instruction enum by introducing TableSwitch and LookupSwitch structs

### DIFF
--- a/ristretto_classfile/src/attributes/attribute.rs
+++ b/ristretto_classfile/src/attributes/attribute.rs
@@ -1787,24 +1787,17 @@ impl fmt::Display for Attribute {
                     let mut instruction =
                         Instruction::from_bytes(&mut cursor).map_err(|_| fmt::Error)?;
                     match instruction {
-                        Instruction::Tableswitch {
-                            ref mut default,
-                            ref mut offsets,
-                            ..
-                        } => {
+                        Instruction::Tableswitch(ref mut table_switch) => {
                             let position = i32::try_from(index).map_err(|_| fmt::Error)?;
-                            *default += position;
-                            for offset in offsets {
+                            table_switch.default += position;
+                            for offset in &mut table_switch.offsets {
                                 *offset += position;
                             }
                         }
-                        Instruction::Lookupswitch {
-                            ref mut default,
-                            ref mut pairs,
-                        } => {
+                        Instruction::Lookupswitch(ref mut lookupswitch) => {
                             let position = i32::try_from(index).map_err(|_| fmt::Error)?;
-                            *default += position;
-                            for offset in pairs.values_mut() {
+                            lookupswitch.default += position;
+                            for offset in lookupswitch.pairs.values_mut() {
                                 *offset += position;
                             }
                         }

--- a/ristretto_classfile/src/attributes/mod.rs
+++ b/ristretto_classfile/src/attributes/mod.rs
@@ -143,7 +143,7 @@ pub use exception_table_entry::ExceptionTableEntry;
 pub use exports::Exports;
 pub use exports_flags::ExportsFlags;
 pub use inner_class::InnerClass;
-pub use instruction::Instruction;
+pub use instruction::{Instruction, LookupSwitch, TableSwitch};
 pub use line_number::LineNumber;
 pub use local_variable_table::LocalVariableTable;
 pub use local_variable_target::LocalVariableTarget;

--- a/ristretto_jit/src/control_flow_graph/blocks.rs
+++ b/ristretto_jit/src/control_flow_graph/blocks.rs
@@ -137,10 +137,8 @@ pub(crate) fn get_blocks(
                 insert_stack(&mut stack_states, address, &stack)?;
                 create_block_with_parameters(function_builder, &stack_states, address, &mut blocks);
             }
-            Instruction::Tableswitch {
-                default, offsets, ..
-            } => {
-                let default = usize::try_from(*default)?;
+            Instruction::Tableswitch(table_switch) => {
+                let default = usize::try_from(table_switch.default)?;
                 let default = program_counter.checked_add(default).ok_or_else(|| {
                     InternalError(format!(
                         "Invalid address calculation: {program_counter} + {default}"
@@ -149,7 +147,7 @@ pub(crate) fn get_blocks(
                 insert_stack(&mut stack_states, default, &stack)?;
                 create_block_with_parameters(function_builder, &stack_states, default, &mut blocks);
 
-                for offset in offsets {
+                for offset in &table_switch.offsets {
                     let address = usize::try_from(*offset)?;
                     let address = program_counter.checked_add(address).ok_or_else(|| {
                         InternalError(format!(
@@ -165,8 +163,8 @@ pub(crate) fn get_blocks(
                     );
                 }
             }
-            Instruction::Lookupswitch { default, pairs } => {
-                let default = usize::try_from(*default)?;
+            Instruction::Lookupswitch(lookup_switch) => {
+                let default = usize::try_from(lookup_switch.default)?;
                 let default = program_counter.checked_add(default).ok_or_else(|| {
                     InternalError(format!(
                         "Invalid address calculation: {program_counter} + {default}"
@@ -175,7 +173,7 @@ pub(crate) fn get_blocks(
                 insert_stack(&mut stack_states, default, &stack)?;
                 create_block_with_parameters(function_builder, &stack_states, default, &mut blocks);
 
-                for (_key, offset) in pairs {
+                for (_key, offset) in &lookup_switch.pairs {
                     let address = usize::try_from(*offset)?;
                     let address = program_counter.checked_add(address).ok_or_else(|| {
                         InternalError(format!(

--- a/ristretto_jit/src/control_flow_graph/control_flow.rs
+++ b/ristretto_jit/src/control_flow_graph/control_flow.rs
@@ -60,7 +60,7 @@ impl InstructionControlFlow for Instruction {
 mod tests {
     use super::*;
     use indexmap::IndexMap;
-    use ristretto_classfile::attributes::Instruction;
+    use ristretto_classfile::attributes::{Instruction, LookupSwitch, TableSwitch};
 
     #[test]
     fn test_changes_control_flow() {
@@ -83,16 +83,16 @@ mod tests {
             Instruction::Goto_w(0),
             Instruction::Jsr(0),
             Instruction::Jsr_w(0),
-            Instruction::Tableswitch {
+            Instruction::Tableswitch(TableSwitch {
                 default: 0,
                 low: 0,
                 high: 0,
                 offsets: vec![0],
-            },
-            Instruction::Lookupswitch {
+            }),
+            Instruction::Lookupswitch(LookupSwitch {
                 default: 0,
                 pairs: IndexMap::new(),
-            },
+            }),
             Instruction::Ret(0),
             Instruction::Ret_w(0),
             Instruction::Return,

--- a/ristretto_jit/src/control_flow_graph/instruction.rs
+++ b/ristretto_jit/src/control_flow_graph/instruction.rs
@@ -671,7 +671,7 @@ fn pop_field_type(stack: &mut TypeStack, field_type: &FieldType) -> Result<Type>
 mod tests {
     use super::*;
     use indexmap::IndexMap;
-    use ristretto_classfile::attributes::ArrayType;
+    use ristretto_classfile::attributes::{ArrayType, LookupSwitch, TableSwitch};
 
     #[test]
     fn test_ldc_integer() -> Result<()> {
@@ -2051,16 +2051,16 @@ mod tests {
     #[test]
     fn test_simulate_switch_instructions() -> Result<()> {
         let instructions = vec![
-            Instruction::Tableswitch {
+            Instruction::Tableswitch(TableSwitch {
                 default: 3,
                 low: 1,
                 high: 2,
                 offsets: vec![1; 2],
-            },
-            Instruction::Lookupswitch {
+            }),
+            Instruction::Lookupswitch(LookupSwitch {
                 default: 3,
                 pairs: IndexMap::new(),
-            },
+            }),
         ];
         for instruction in instructions {
             let mut stack = TypeStack::new();

--- a/ristretto_vm/src/frame.rs
+++ b/ristretto_vm/src/frame.rs
@@ -26,7 +26,7 @@ use crate::instruction::{
 use crate::{LocalVariables, OperandStack, Result, Thread};
 use async_recursion::async_recursion;
 use byte_unit::{Byte, UnitType};
-use ristretto_classfile::attributes::Instruction;
+use ristretto_classfile::attributes::{Instruction, LookupSwitch, TableSwitch};
 use ristretto_classloader::{Class, Method, Value};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
@@ -500,16 +500,16 @@ impl Frame {
             Instruction::Goto(address) => goto(*address),
             Instruction::Jsr(address) => jsr(stack, *address),
             Instruction::Ret(index) => ret(locals, *index),
-            Instruction::Tableswitch {
+            Instruction::Tableswitch(TableSwitch {
                 default,
                 low,
                 high,
                 offsets,
-            } => {
+            }) => {
                 let program_counter = self.program_counter.load(Ordering::Relaxed);
                 tableswitch(stack, program_counter, *default, *low, *high, offsets)
             }
-            Instruction::Lookupswitch { default, pairs } => {
+            Instruction::Lookupswitch(LookupSwitch { default, pairs }) => {
                 let program_counter = self.program_counter.load(Ordering::Relaxed);
                 lookupswitch(stack, program_counter, *default, pairs)
             }


### PR DESCRIPTION
Reduces size of `Instruction` enum from 56 bytes to 8 bytes.