### PR TITLE
ristretto-v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,175 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## `ristretto_pom` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_pom-v0.29.0...ristretto_pom-v0.32.0) - 2026-07-23
+
+### Added
+- implement sockets
+
+### Other
+- add clippy lints
+- improve pom testing
+- initial wasm32-wasip2 tests
+
+## `ristretto_java` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/v0.31.0...v0.32.0) - 2026-07-23
+
+### Added
+- add ability to configure TLS providers
+- implement javax/sound
+- implement sun/nio/ch
+- implement sun/nio/fs
+- implement sun/nio/ch/Windows
+- implement sun/nio/ch/sctp
+- implement java/util/prefs/WindowsPreferences
+- implement sun/util/locale/provider/HostLocaleProviderAdapterImpl
+- implement jdk/internal/platform/CgroupMetrics
+- implement sockets
+
+### Fixed
+- correct file io/nio errors
+- correct windows jdk installation directory
+- update intrinsics for current java versions
+- consume file lock ranges on non-Windows
+
+### Other
+- add clippy lints
+- update dependencies
+- rename ristretto_cli crate to ristretto_java
+- refactor mod.rs to named modules
+- update to Rust 1.97.1
+- improve classfile testing
+- update java versions
+- update to cranelift=0.134.2
+- improve jimage testing
+- improve macro testing
+- improve pom testing
+- initial wasm32-wasip2 tests
+- improve types testing
+
+## `ristretto_vm` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_vm-v0.31.0...ristretto_vm-v0.32.0) - 2026-07-23
+
+### Added
+- add ability to configure TLS providers
+- implement sun/nio/ch
+- implement sun/nio/fs
+- implement javax/sound
+- implement sun/nio/ch/sctp
+- implement java/util/prefs/WindowsPreferences
+
+### Fixed
+- correct file io/nio errors
+
+### Other
+- refactor mod.rs to named modules
+- add clippy lints
+- update dependencies
+
+## `ristretto_intrinsics` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_intrinsics-v0.31.0...ristretto_intrinsics-v0.32.0) - 2026-07-23
+
+### Added
+- add ability to configure TLS providers
+- implement sun/nio/ch
+- implement sun/nio/fs
+- implement javax/sound
+- implement sun/nio/ch/Windows
+- implement sun/nio/ch/sctp
+- implement java/util/prefs/WindowsPreferences
+- implement sun/util/locale/provider/HostLocaleProviderAdapterImpl
+- implement jdk/internal/platform/CgroupMetrics
+
+### Fixed
+- update intrinsics for current java versions
+- consume file lock ranges on non-Windows
+- correct file io/nio errors
+
+### Other
+- update java versions
+- update to cranelift=0.134.2
+- update to Rust 1.97.1
+- add clippy lints
+- update dependencies
+
+## `ristretto_types` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_types-v0.31.0...ristretto_types-v0.32.0) - 2026-07-23
+
+### Added
+- add ability to configure TLS providers
+- implement sun/nio/ch
+- implement sun/nio/fs
+- implement sun/nio/ch/sctp
+- implement java/util/prefs/WindowsPreferences
+
+### Fixed
+- correct file io/nio errors
+
+### Other
+- refactor mod.rs to named modules
+- update to Rust 1.97.1
+- add clippy lints
+- update dependencies
+- improve types testing
+
+## `ristretto_jit` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_jit-v0.31.0...ristretto_jit-v0.32.0) - 2026-07-23
+
+### Fixed
+- correct file io/nio errors
+
+### Other
+- update to cranelift=0.134.2
+- refactor mod.rs to named modules
+- add clippy lints
+- update dependencies
+
+## `ristretto_macros` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_macros-v0.31.0...ristretto_macros-v0.32.0) - 2026-07-23
+
+### Other
+- refactor mod.rs to named modules
+- add clippy lints
+- update dependencies
+- improve macro testing
+
+## `ristretto_classloader` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_classloader-v0.31.0...ristretto_classloader-v0.32.0) - 2026-07-23
+
+### Added
+- add ability to configure TLS providers
+
+### Fixed
+- correct file io/nio errors
+- correct windows jdk installation directory
+
+### Other
+- update java versions
+- refactor mod.rs to named modules
+- add clippy lints
+- update dependencies
+
+## `ristretto_jimage` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_jimage-v0.31.0...ristretto_jimage-v0.32.0) - 2026-07-23
+
+### Fixed
+- correct file io/nio errors
+
+### Other
+- add clippy lints
+- update dependencies
+- improve jimage testing
+
+## `ristretto_gc` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_gc-v0.31.0...ristretto_gc-v0.32.0) - 2026-07-23
+
+### Other
+- add clippy lints
+- update dependencies
+
+## `ristretto_classfile` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_classfile-v0.31.0...ristretto_classfile-v0.32.0) - 2026-07-23
+
+### Added
+- add ability to configure TLS providers
+
+### Other
+- refactor mod.rs to named modules
+- update to Rust 1.97.1
+- add clippy lints
+- update dependencies
+- improve classfile testing
+
 ##
 `ristretto_pom` - [0.31.0](https://github.com/theseus-rs/ristretto/compare/ristretto_pom-v0.29.0...ristretto_pom-v0.31.0) - 2026-05-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "class_loader"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ristretto_classloader",
  "tokio",
@@ -1020,7 +1020,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded_jvm"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ristretto_vm",
  "tokio",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "read_class"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "ristretto_classfile",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_classfile"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_classloader"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "bytemuck",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_gc"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "dashmap",
  "parking_lot",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_intrinsics"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "async-recursion",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_java"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "anstyle",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_jimage"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "byteorder",
  "memchr",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_jit"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "cranelift",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_macros"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "async-recursion",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_pom"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "quick-xml",
  "serde",
@@ -3102,14 +3102,14 @@ dependencies = [
 
 [[package]]
 name = "ristretto_test_util"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "ristretto_types"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.13.1",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "ristretto_vm"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash 0.8.12",
  "async-recursion",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "runtime_class_loader"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ristretto_classloader",
  "tokio",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "sound_midi"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ristretto_vm",
  "tokio",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "sound_wav"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ristretto_vm",
  "tokio",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "write_class"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ristretto_classfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ keywords = ["java", "jvm"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/theseus-rs/ristretto"
 rust-version = "1.97.1"
-version = "0.31.0"
+version = "0.32.0"
 
 [workspace.lints.rust]
 dead_code = "allow"
@@ -114,7 +114,7 @@ sys-locale = "0.3.2"
 tar = "0.4.46"
 tempfile = "3.27.0"
 test-log = "0.2.21"
-ristretto_test_util = { path = "ristretto_test_util", version = "0.31.0" }
+ristretto_test_util = { path = "ristretto_test_util", version = "0.32.0" }
 thiserror = "2.0.19"
 thread-priority = "3.1.1"
 tokio = { version = "1.53.1", default-features = false, features = ["macros", "rt", "sync", "time"] }

--- a/ristretto_classloader/Cargo.toml
+++ b/ristretto_classloader/Cargo.toml
@@ -21,9 +21,9 @@ flate2 = { workspace = true }
 indexmap = { workspace = true }
 memchr = { workspace = true }
 parking_lot = { workspace = true }
-ristretto_classfile = { path = "../ristretto_classfile", version = "0.31.0" }
-ristretto_gc = { path = "../ristretto_gc", version = "0.31.0" }
-ristretto_jimage = { path = "../ristretto_jimage", version = "0.31.0" }
+ristretto_classfile = { path = "../ristretto_classfile", version = "0.32.0" }
+ristretto_gc = { path = "../ristretto_gc", version = "0.32.0" }
+ristretto_jimage = { path = "../ristretto_jimage", version = "0.32.0" }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/ristretto_intrinsics/Cargo.toml
+++ b/ristretto_intrinsics/Cargo.toml
@@ -26,11 +26,11 @@ flate2 = { workspace = true }
 getrandom = { workspace = true }
 jiff = { workspace = true }
 parking_lot = { workspace = true }
-ristretto_classfile = { path = "../ristretto_classfile", version = "0.31.0" }
-ristretto_classloader = { path = "../ristretto_classloader", version = "0.31.0", default-features = false }
-ristretto_gc = { path = "../ristretto_gc", version = "0.31.0" }
-ristretto_macros = { path = "../ristretto_macros", version = "0.31.0" }
-ristretto_types = { path = "../ristretto_types", version = "0.31.0" }
+ristretto_classfile = { path = "../ristretto_classfile", version = "0.32.0" }
+ristretto_classloader = { path = "../ristretto_classloader", version = "0.32.0", default-features = false }
+ristretto_gc = { path = "../ristretto_gc", version = "0.32.0" }
+ristretto_macros = { path = "../ristretto_macros", version = "0.32.0" }
+ristretto_types = { path = "../ristretto_types", version = "0.32.0" }
 sys-locale = { workspace = true }
 tracing = { workspace = true }
 zerocopy = { workspace = true }
@@ -115,8 +115,8 @@ audio = [
 ]
 
 [dev-dependencies]
-ristretto_test_util = { path = "../ristretto_test_util", version = "0.31.0" }
-ristretto_vm = { path = "../ristretto_vm", version = "0.31.0", default-features = false }
+ristretto_test_util = { path = "../ristretto_test_util", version = "0.32.0" }
+ristretto_vm = { path = "../ristretto_vm", version = "0.32.0", default-features = false }
 tempfile = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/ristretto_java/Cargo.toml
+++ b/ristretto_java/Cargo.toml
@@ -29,8 +29,8 @@ workspace = true
 ahash = { workspace = true }
 anstyle = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-ristretto_gc = { path = "../ristretto_gc", version = "0.31.0" }
-ristretto_vm = { path = "../ristretto_vm", version = "0.31.0", default-features = false }
+ristretto_gc = { path = "../ristretto_gc", version = "0.32.0" }
+ristretto_vm = { path = "../ristretto_vm", version = "0.32.0", default-features = false }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/ristretto_jit/Cargo.toml
+++ b/ristretto_jit/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 ahash = { workspace = true }
-ristretto_classfile = { path = "../ristretto_classfile", version = "0.31.0" }
+ristretto_classfile = { path = "../ristretto_classfile", version = "0.32.0" }
 thiserror = { workspace = true }
 zerocopy = { workspace = true }
 

--- a/ristretto_macros/Cargo.toml
+++ b/ristretto_macros/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 ahash = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-ristretto_classfile = { path = "../ristretto_classfile", version = "0.31.0" }
+ristretto_classfile = { path = "../ristretto_classfile", version = "0.32.0" }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 walkdir = { workspace = true }
 

--- a/ristretto_types/Cargo.toml
+++ b/ristretto_types/Cargo.toml
@@ -21,10 +21,10 @@ workspace = true
 ahash = { workspace = true }
 bitflags = { workspace = true }
 parking_lot = { workspace = true }
-ristretto_classfile = { path = "../ristretto_classfile", version = "0.31.0" }
-ristretto_classloader = { path = "../ristretto_classloader", version = "0.31.0", default-features = false }
-ristretto_gc = { path = "../ristretto_gc", version = "0.31.0" }
-ristretto_jit = { path = "../ristretto_jit", version = "0.31.0" }
+ristretto_classfile = { path = "../ristretto_classfile", version = "0.32.0" }
+ristretto_classloader = { path = "../ristretto_classloader", version = "0.32.0", default-features = false }
+ristretto_gc = { path = "../ristretto_gc", version = "0.32.0" }
+ristretto_jit = { path = "../ristretto_jit", version = "0.32.0" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 zerocopy = { workspace = true }

--- a/ristretto_vm/Cargo.toml
+++ b/ristretto_vm/Cargo.toml
@@ -28,13 +28,13 @@ flate2 = { workspace = true }
 indexmap = { workspace = true }
 jiff = { workspace = true }
 parking_lot = { workspace = true }
-ristretto_classfile = { path = "../ristretto_classfile", version = "0.31.0" }
-ristretto_classloader = { path = "../ristretto_classloader", version = "0.31.0", default-features = false }
-ristretto_gc = { path = "../ristretto_gc", version = "0.31.0" }
-ristretto_intrinsics = { path = "../ristretto_intrinsics", version = "0.31.0", default-features = false }
-ristretto_jit = { path = "../ristretto_jit", version = "0.31.0" }
-ristretto_macros = { path = "../ristretto_macros", version = "0.31.0" }
-ristretto_types = { path = "../ristretto_types", version = "0.31.0" }
+ristretto_classfile = { path = "../ristretto_classfile", version = "0.32.0" }
+ristretto_classloader = { path = "../ristretto_classloader", version = "0.32.0", default-features = false }
+ristretto_gc = { path = "../ristretto_gc", version = "0.32.0" }
+ristretto_intrinsics = { path = "../ristretto_intrinsics", version = "0.32.0", default-features = false }
+ristretto_jit = { path = "../ristretto_jit", version = "0.32.0" }
+ristretto_macros = { path = "../ristretto_macros", version = "0.32.0" }
+ristretto_types = { path = "../ristretto_types", version = "0.32.0" }
 sys-locale = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `ristretto_classfile`: 0.31.0 -> 0.32.0 (✓ API compatible changes)
* `ristretto_gc`: 0.31.0 -> 0.32.0 (⚠ API breaking changes)
* `ristretto_jimage`: 0.31.0 -> 0.32.0 (✓ API compatible changes)
* `ristretto_classloader`: 0.31.0 -> 0.32.0 (⚠ API breaking changes)
* `ristretto_test_util`: 0.31.0 -> 0.32.0
* `ristretto_macros`: 0.31.0 -> 0.32.0
* `ristretto_jit`: 0.31.0 -> 0.32.0 (✓ API compatible changes)
* `ristretto_types`: 0.31.0 -> 0.32.0 (⚠ API breaking changes)
* `ristretto_intrinsics`: 0.31.0 -> 0.32.0 (✓ API compatible changes)
* `ristretto_vm`: 0.31.0 -> 0.32.0 (✓ API compatible changes)
* `ristretto_java`: 0.31.0 -> 0.32.0
* `ristretto_pom`: 0.29.0 -> 0.32.0

### ⚠ `ristretto_gc` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:InvalidPointer in /tmp/.tmpkd5msn/ristretto/ristretto_gc/src/error.rs:25

--- failure method_receiver_type_changed: method receiver changed type ---

Description:
A method's receiver changed to a different type.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_receiver_type_changed.ron

Failed in:
  ristretto_gc::GarbageCollector::create_root_guard now takes &Arc<Self>, not &Self, in /tmp/.tmpkd5msn/ristretto/ristretto_gc/src/collector.rs:418
```

### ⚠ `ristretto_classloader` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature native-tls in the package's Cargo.toml
  feature rustls-tls in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  SystemModuleFinder::package_map_from_jimage, previously in file /tmp/.tmpxv8xLW/ristretto_classloader/src/module/finder.rs:175
  ResolvedConfiguration::from_package_map, previously in file /tmp/.tmpxv8xLW/ristretto_classloader/src/module/resolution.rs:549
  ResolvedConfiguration::resolve_from_jimage, previously in file /tmp/.tmpxv8xLW/ristretto_classloader/src/module/resolution.rs:566
```

### ⚠ `ristretto_types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SocketHandle.is_unix in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/handles/socket.rs:234
  field SocketHandle.lifecycle in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/handles/socket.rs:238

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant JavaError:ConnectionResetException in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/java_error.rs:90
  variant JavaError:InterruptedIoException in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/java_error.rs:162
  variant JavaError:NoRouteToHostException in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/java_error.rs:174
  variant JavaError:PortUnreachableException in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/java_error.rs:180
  variant JavaError:ProtocolException in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/java_error.rs:216
  variant JavaError:UnknownHostException in /tmp/.tmpkd5msn/ristretto/ristretto_types/src/java_error.rs:255

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method is_lightweight_mode of trait ModuleAccess, previously in file /tmp/.tmpxv8xLW/ristretto_types/src/module_access.rs:133
  method is_lightweight_mode of trait ModuleAccess, previously in file /tmp/.tmpxv8xLW/ristretto_types/src/module_access.rs:133
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ristretto_classfile`

<blockquote>


## `ristretto_classfile` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_classfile-v0.31.0...ristretto_classfile-v0.32.0) - 2026-07-23

### Added
- add ability to configure TLS providers

### Other
- refactor mod.rs to named modules
- update to Rust 1.97.1
- add clippy lints
- update dependencies
- improve classfile testing
</blockquote>

## `ristretto_gc`

<blockquote>


## `ristretto_gc` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_gc-v0.31.0...ristretto_gc-v0.32.0) - 2026-07-23

### Other
- add clippy lints
- update dependencies
</blockquote>

## `ristretto_jimage`

<blockquote>


## `ristretto_jimage` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_jimage-v0.31.0...ristretto_jimage-v0.32.0) - 2026-07-23

### Fixed
- correct file io/nio errors

### Other
- add clippy lints
- update dependencies
- improve jimage testing
</blockquote>

## `ristretto_classloader`

<blockquote>


## `ristretto_classloader` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_classloader-v0.31.0...ristretto_classloader-v0.32.0) - 2026-07-23

### Added
- add ability to configure TLS providers

### Fixed
- correct file io/nio errors
- correct windows jdk installation directory

### Other
- update java versions
- refactor mod.rs to named modules
- add clippy lints
- update dependencies
</blockquote>


## `ristretto_macros`

<blockquote>


## `ristretto_macros` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_macros-v0.31.0...ristretto_macros-v0.32.0) - 2026-07-23

### Other
- refactor mod.rs to named modules
- add clippy lints
- update dependencies
- improve macro testing
</blockquote>

## `ristretto_jit`

<blockquote>


## `ristretto_jit` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_jit-v0.31.0...ristretto_jit-v0.32.0) - 2026-07-23

### Fixed
- correct file io/nio errors

### Other
- update to cranelift=0.134.2
- refactor mod.rs to named modules
- add clippy lints
- Merge branch 'main' into update-cranelift
- update dependencies
</blockquote>

## `ristretto_types`

<blockquote>


## `ristretto_types` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_types-v0.31.0...ristretto_types-v0.32.0) - 2026-07-23

### Added
- add ability to configure TLS providers
- implement sun/nio/ch
- implement sun/nio/fs
- implement sun/nio/ch/sctp
- implement java/util/prefs/WindowsPreferences

### Fixed
- correct file io/nio errors

### Other
- Merge pull request #771 from theseus-rs/add-tls-providers
- refactor mod.rs to named modules
- update to Rust 1.97.1
- add clippy lints
- update dependencies
- improve types testing
</blockquote>

## `ristretto_intrinsics`

<blockquote>


## `ristretto_intrinsics` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_intrinsics-v0.31.0...ristretto_intrinsics-v0.32.0) - 2026-07-23

### Added
- add ability to configure TLS providers
- implement sun/nio/ch
- implement sun/nio/fs
- implement javax/sound
- implement sun/nio/ch/Windows
- implement sun/nio/ch/sctp
- implement java/util/prefs/WindowsPreferences
- implement sun/util/locale/provider/HostLocaleProviderAdapterImpl
- implement jdk/internal/platform/CgroupMetrics

### Fixed
- update intrinsics for current java versions
- consume file lock ranges on non-Windows
- correct file io/nio errors

### Other
- Merge pull request #771 from theseus-rs/add-tls-providers
- update java versions
- update to cranelift=0.134.2
- Merge branch 'main' into refactor-modules
- Merge pull request #765 from theseus-rs/impl-iocp
- Merge pull request #762 from theseus-rs/update-to-rust-1.97.1
- update to Rust 1.97.1
- add clippy lints
- update dependencies
</blockquote>

## `ristretto_vm`

<blockquote>


## `ristretto_vm` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_vm-v0.31.0...ristretto_vm-v0.32.0) - 2026-07-23

### Added
- add ability to configure TLS providers
- implement sun/nio/ch
- implement sun/nio/fs
- implement javax/sound
- implement sun/nio/ch/sctp
- implement java/util/prefs/WindowsPreferences

### Fixed
- correct file io/nio errors

### Other
- Merge pull request #771 from theseus-rs/add-tls-providers
- refactor mod.rs to named modules
- add clippy lints
- update dependencies
</blockquote>

## `ristretto_java`

<blockquote>


## `ristretto_java` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/v0.31.0...v0.32.0) - 2026-07-23

### Added
- add ability to configure TLS providers
- implement javax/sound
- implement sun/nio/ch
- implement sun/nio/fs
- implement sun/nio/ch/Windows
- implement sun/nio/ch/sctp
- implement java/util/prefs/WindowsPreferences
- implement sun/util/locale/provider/HostLocaleProviderAdapterImpl
- implement jdk/internal/platform/CgroupMetrics
- implement sockets

### Fixed
- correct file io/nio errors
- correct windows jdk installation directory
- update intrinsics for current java versions
- consume file lock ranges on non-Windows

### Other
- add clippy lints
- update dependencies
- rename ristretto_cli crate to ristretto_java
- refactor mod.rs to named modules
- update to Rust 1.97.1
- improve classfile testing
- update java versions
- Merge pull request #771 from theseus-rs/add-tls-providers
- update to cranelift=0.134.2
- Merge branch 'main' into refactor-modules
- Merge pull request #765 from theseus-rs/impl-iocp
- Merge pull request #762 from theseus-rs/update-to-rust-1.97.1
- improve jimage testing
- Merge branch 'main' into update-cranelift
- improve macro testing
- improve pom testing
- initial wasm32-wasip2 tests
- improve types testing
</blockquote>

## `ristretto_pom`

<blockquote>


## `ristretto_pom` - [0.32.0](https://github.com/theseus-rs/ristretto/compare/ristretto_pom-v0.29.0...ristretto_pom-v0.32.0) - 2026-07-23

### Added
- implement sockets

### Other
- add clippy lints
- improve pom testing
- initial wasm32-wasip2 tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).