### PR TITLE
perf: reuse call-frame storage and eliminate cached call argument allocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
         run: |
           rustup target install ${{ matrix.target }}
-          cargo clippy --workspace --target ${{ matrix.target }} -- -D warnings
+          cargo clippy --workspace --tests --target ${{ matrix.target }} -- -D warnings
 
       - name: Run clippy
         if: ${{ matrix.platform == 'linux-x64' || matrix.platform == 'macos-arm' || matrix.platform == 'windows-arm' }}
@@ -179,7 +179,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
           CARGO_TARGET_WASM32_WASIP2_RUNNER: "wasmtime -W max-wasm-stack=8388608 -S http -S inherit-network -S allow-ip-name-lookup --dir=. --dir=${{ github.workspace }}::${{ github.workspace }} --env=HOME=/home --dir=${{ runner.temp }}::/home --env=TMPDIR=/tmp --dir=/tmp::/tmp"
         run: |
-          cargo test --workspace --tests --exclude ristretto_classfile --target ${{ matrix.target }} -- --test-threads=1
+          cargo test --workspace --tests --target ${{ matrix.target }} -- --test-threads=1
 
       - name: Tests
         if: ${{ matrix.platform == 'linux-x64' }}

--- a/examples/resolver/src/main.rs
+++ b/examples/resolver/src/main.rs
@@ -17,7 +17,7 @@
 //! materialize every selected JAR after printing the tree.
 
 #![cfg_attr(
-    test,
+    all(test, not(target_family = "wasm")),
     expect(
         clippy::panic_in_result_fn,
         reason = "the example test uses assertions while propagating resolver errors"

--- a/ristretto_classfile/Cargo.toml
+++ b/ristretto_classfile/Cargo.toml
@@ -27,10 +27,12 @@ anyhow = { workspace = true }
 criterion = { workspace = true }
 flate2 = { workspace = true }
 indoc = { workspace = true }
-reqwest = { workspace = true, features = ["rustls"] }
 tar = { workspace = true }
 tokio = { workspace = true }
 zip = { workspace = true, features = ["deflate"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+reqwest = { workspace = true, features = ["rustls"] }
 
 [[bench]]
 harness = false

--- a/ristretto_classfile/src/verifiers/bytecode/cache.rs
+++ b/ristretto_classfile/src/verifiers/bytecode/cache.rs
@@ -564,6 +564,7 @@ mod tests {
         assert_eq!(stats.descriptor_hits, 0);
     }
 
+    #[cfg(panic = "unwind")]
     #[test]
     fn test_cache_stats_poisoned_lock_is_ignored() {
         let cache = VerificationCache::new(true);

--- a/ristretto_classloader/src/class/layout_tests.rs
+++ b/ristretto_classloader/src/class/layout_tests.rs
@@ -97,6 +97,7 @@ fn verification_is_cached_and_invalidated_by_constant_pool_mutation() -> Result<
     Ok(())
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn concurrent_layout_finalization_preserves_shared_storage() -> Result<()> {
     let base = class("Base", None, "base")?;

--- a/ristretto_intrinsics/src/lib.rs
+++ b/ristretto_intrinsics/src/lib.rs
@@ -13,9 +13,15 @@
 #![cfg_attr(
     test,
     expect(
-        clippy::expect_used,
         clippy::panic_in_result_fn,
-        reason = "intrinsic unit tests use assertions and fixture setup expects in Result-returning tests"
+        reason = "intrinsic unit tests use assertions in Result-returning tests"
+    )
+)]
+#![cfg_attr(
+    all(test, not(target_family = "wasm")),
+    expect(
+        clippy::expect_used,
+        reason = "native intrinsic unit tests use fixture setup expects"
     )
 )]
 

--- a/ristretto_intrinsics/src/net_helpers.rs
+++ b/ristretto_intrinsics/src/net_helpers.rs
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    fn inet_address_values_and_socket_conversions() -> Result<()> {
+    fn inet_address_values() {
         let v4 = InetAddressValue::V4(Ipv4Addr::new(192, 0, 2, 1));
         assert_eq!(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), v4.ip());
         assert_eq!(vec![192, 0, 2, 1], v4.octets());
@@ -804,49 +804,53 @@ mod tests {
         assert_eq!(IpAddr::V6(v6_address), v6.ip());
         assert_eq!(v6_address.octets(), v6.octets().as_slice());
         assert_eq!(7, v6.scope_id());
+    }
 
-        #[cfg(not(target_family = "wasm"))]
-        {
-            assert_eq!(
-                SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1234)),
-                std_socket_address(v4, 1234, false)?
-            );
-            assert_eq!(
-                SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1).to_ipv6_mapped(), 1234)),
-                std_socket_address(v4, 1234, true)?
-            );
-            assert_eq!(
-                SocketAddr::from((Ipv6Addr::UNSPECIFIED, 1234)),
-                std_socket_address(InetAddressValue::V4(Ipv4Addr::UNSPECIFIED), 1234, true)?
-            );
-            assert_eq!(
-                SocketAddr::V6(SocketAddrV6::new(v6_address, 1234, 0, 7)),
-                std_socket_address(v6, 1234, true)?
-            );
-            assert!(std_socket_address(v6, 1234, false).is_err());
-            assert!(std_socket_address(v4, -1, false).is_err());
-            assert!(std_socket_address(v4, 65_536, false).is_err());
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn socket_conversions() -> Result<()> {
+        let v4 = InetAddressValue::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let v6_address = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let v6 = InetAddressValue::V6(v6_address, 7);
+        assert_eq!(
+            SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1234)),
+            std_socket_address(v4, 1234, false)?
+        );
+        assert_eq!(
+            SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1).to_ipv6_mapped(), 1234)),
+            std_socket_address(v4, 1234, true)?
+        );
+        assert_eq!(
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 1234)),
+            std_socket_address(InetAddressValue::V4(Ipv4Addr::UNSPECIFIED), 1234, true)?
+        );
+        assert_eq!(
+            SocketAddr::V6(SocketAddrV6::new(v6_address, 1234, 0, 7)),
+            std_socket_address(v6, 1234, true)?
+        );
+        assert!(std_socket_address(v6, 1234, false).is_err());
+        assert!(std_socket_address(v4, -1, false).is_err());
+        assert!(std_socket_address(v4, 65_536, false).is_err());
 
-            let mapped = Ipv4Addr::LOCALHOST.to_ipv6_mapped();
-            assert_eq!(
-                SocketAddr::from((Ipv4Addr::LOCALHOST, 80)),
-                std_socket_address(InetAddressValue::V6(mapped, 0), 80, false)?
-            );
-            assert_eq!(
-                InetAddressValue::V4(Ipv4Addr::LOCALHOST),
-                inet_address_from_socket(SocketAddr::from((mapped, 80)))
-            );
-            assert_eq!(
-                v6,
-                inet_address_from_socket(SocketAddr::V6(SocketAddrV6::new(v6_address, 80, 0, 7)))
-            );
-            assert_eq!(
-                SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1234)),
-                socket_address(v4, 1234, false)?
-                    .as_socket()
-                    .expect("internet address")
-            );
-        }
+        let mapped = Ipv4Addr::LOCALHOST.to_ipv6_mapped();
+        assert_eq!(
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 80)),
+            std_socket_address(InetAddressValue::V6(mapped, 0), 80, false)?
+        );
+        assert_eq!(
+            InetAddressValue::V4(Ipv4Addr::LOCALHOST),
+            inet_address_from_socket(SocketAddr::from((mapped, 80)))
+        );
+        assert_eq!(
+            v6,
+            inet_address_from_socket(SocketAddr::V6(SocketAddrV6::new(v6_address, 80, 0, 7)))
+        );
+        assert_eq!(
+            SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1234)),
+            socket_address(v4, 1234, false)?
+                .as_socket()
+                .expect("internet address")
+        );
         Ok(())
     }
 

--- a/ristretto_jit/src/control_flow_graph/type_stack.rs
+++ b/ristretto_jit/src/control_flow_graph/type_stack.rs
@@ -128,6 +128,10 @@ impl TypeStack {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "tests inspect stack fixture elements"
+)]
 mod tests {
     use super::*;
 

--- a/ristretto_jit/src/function.rs
+++ b/ristretto_jit/src/function.rs
@@ -222,10 +222,11 @@ mod tests {
 
     #[test]
     fn test_function() -> Result<()> {
-        let function = Function::new(return_42);
-        assert!(format!("{function:?}").contains("Function"));
-        let cloned_function = function.clone();
-        drop(function);
+        let cloned_function = {
+            let function = Function::new(return_42);
+            assert!(format!("{function:?}").contains("Function"));
+            function.clone()
+        };
         let value = cloned_function
             .execute(&[], std::ptr::null())?
             .expect("value");

--- a/ristretto_jit/src/lib.rs
+++ b/ristretto_jit/src/lib.rs
@@ -30,9 +30,8 @@
 #![cfg_attr(
     test,
     expect(
-        clippy::indexing_slicing,
         clippy::panic_in_result_fn,
-        reason = "unit tests use direct fixture indexing and assertions with Result-returning tests"
+        reason = "unit tests use assertions with Result-returning tests"
     )
 )]
 #[cfg(all(

--- a/ristretto_pom/src/lib.rs
+++ b/ristretto_pom/src/lib.rs
@@ -24,9 +24,8 @@
 #![cfg_attr(
     test,
     expect(
-        clippy::indexing_slicing,
         clippy::panic_in_result_fn,
-        reason = "unit tests use direct fixture indexing and assertions with Result-returning tests"
+        reason = "unit tests use assertions with Result-returning tests"
     )
 )]
 

--- a/ristretto_pom/src/project.rs
+++ b/ristretto_pom/src/project.rs
@@ -870,6 +870,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_family = "wasm"))]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "test checks the fixture length first"
+    )]
     fn test_parse_pom() -> Result<()> {
         let xml = r"
 <project>

--- a/ristretto_vm/benches/vm.rs
+++ b/ristretto_vm/benches/vm.rs
@@ -83,8 +83,9 @@ async fn vm_init(interpreted: bool) -> Result<()> {
         .class_path(class_path)
         .interpreted(interpreted)
         .build()?;
-    let _ = VM::new(configuration).await?;
-    Ok(())
+    let vm = VM::new(configuration).await?;
+    // Stop daemon tasks before the next iteration so they release the VM and its GC threads.
+    vm.wait_for_non_daemon_threads().await
 }
 
 async fn hello_world(interpreted: bool) -> Result<()> {
@@ -103,7 +104,7 @@ async fn hello_world(interpreted: bool) -> Result<()> {
     let vm = VM::new(configuration).await?;
     let parameters: Vec<&str> = Vec::new();
     let _result = vm.invoke_main(&parameters).await?;
-    Ok(())
+    vm.wait_for_non_daemon_threads().await
 }
 
 criterion_group!(

--- a/ristretto_vm/src/field_ref_cache/tests.rs
+++ b/ristretto_vm/src/field_ref_cache/tests.rs
@@ -568,6 +568,7 @@ async fn mutable_unlinked_receivers_are_rechecked() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[tokio::test]
 async fn receiver_cache_supports_concurrent_publication() -> Result<()> {
     let (_vm, thread) = crate::test::thread().await?;

--- a/ristretto_vm/src/frame.rs
+++ b/ristretto_vm/src/frame.rs
@@ -32,10 +32,9 @@ use ristretto_classloader::{Class, Method, Value};
 use ristretto_types::JavaError::StackOverflowError;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
-use tokio::sync::Mutex;
 use tracing::{Level, debug, event_enabled};
 
-/// Maximum number of bytecodes executed while retaining the frame state lock.
+/// Maximum number of bytecodes executed in one interpreter batch.
 const INSTRUCTION_BATCH_SIZE: usize = 256;
 
 /// A resolved Java method invocation that the thread trampoline must dispatch.
@@ -43,7 +42,7 @@ const INSTRUCTION_BATCH_SIZE: usize = 256;
 pub(crate) struct MethodCall {
     pub(crate) class: Arc<Class>,
     pub(crate) method: Arc<Method>,
-    pub(crate) parameters: Vec<Value>,
+    pub(crate) parameters: CallParameters,
     pub(crate) has_return_type: bool,
 }
 
@@ -125,63 +124,137 @@ pub struct Frame {
     class: Arc<Class>,
     method: Arc<Method>,
     program_counter: AtomicUsize,
-    state: Mutex<Option<FrameState>>,
     method_refs: OnceLock<Arc<ClassReferences<MethodRefEntry>>>,
     field_refs: OnceLock<Arc<ClassReferences<FieldRefEntry>>>,
 }
 
 #[derive(Debug)]
-struct FrameState {
-    locals: LocalVariables,
-    stack: OperandStack,
+pub(crate) struct FrameState {
+    pub(crate) locals: LocalVariables,
+    pub(crate) stack: OperandStack,
 }
 
-impl Frame {
-    /// Create a metadata-only frame for the specified class and method.
-    ///
-    /// JIT execution uses this frame for stack walking without allocating interpreter locals or an
-    /// operand stack. Interpreted calls use [`Frame::with_parameters`] instead.
-    pub fn new(thread: &Weak<Thread>, class: &Arc<Class>, method: &Arc<Method>) -> Self {
-        Frame {
-            thread: thread.clone(),
-            class: class.clone(),
-            method: method.clone(),
-            program_counter: AtomicUsize::new(0),
-            state: Mutex::new(None),
-            method_refs: OnceLock::new(),
-            field_refs: OnceLock::new(),
+impl Default for FrameState {
+    fn default() -> Self {
+        Self {
+            locals: LocalVariables::with_max_size(0),
+            stack: OperandStack::with_max_size(0),
         }
     }
+}
 
-    pub(crate) fn with_parameters(
-        thread: &Weak<Thread>,
-        class: &Arc<Class>,
-        method: &Arc<Method>,
-        mut parameters: Vec<Value>,
-    ) -> Result<Self> {
-        Self::adjust_parameters(&mut parameters, method.max_locals());
-        if parameters.len() > method.max_locals() {
+impl FrameState {
+    pub(crate) fn reset(
+        &mut self,
+        class: &Class,
+        method: &Method,
+        parameters: impl IntoIterator<Item = Value>,
+    ) -> Result<()> {
+        self.stack.reset(method.max_stack());
+        let slots = self.locals.reset(parameters, method.max_locals());
+        if slots > method.max_locals() {
             return Err(InternalError(format!(
-                "Method parameters require {} local-variable slots, but {}.{}{} declares {}",
-                parameters.len(),
+                "Method parameters require {slots} local-variable slots, but {}.{}{} declares {}",
                 class.name(),
                 method.name(),
                 method.descriptor(),
                 method.max_locals()
             )));
         }
-        Ok(Frame {
+        Ok(())
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.locals.clear();
+        self.stack.clear();
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        self.locals.capacity() + self.stack.capacity()
+    }
+}
+
+/// Cached calls leave arguments on the caller's stack until the dispatch boundary.
+#[derive(Debug, PartialEq)]
+pub(crate) enum CallParameters {
+    Owned(Vec<Value>),
+    Stack(usize),
+}
+
+impl From<Vec<Value>> for CallParameters {
+    fn from(values: Vec<Value>) -> Self {
+        Self::Owned(values)
+    }
+}
+
+impl CallParameters {
+    pub(crate) fn as_slice<'a>(&'a self, caller: Option<&'a FrameState>) -> Result<&'a [Value]> {
+        match self {
+            Self::Owned(values) => Ok(values),
+            Self::Stack(count) => Self::caller(caller)?.stack.last_values(*count),
+        }
+    }
+
+    fn caller(caller: Option<&FrameState>) -> Result<&FrameState> {
+        caller.ok_or_else(|| InternalError("Missing caller for stack arguments".to_owned()))
+    }
+
+    pub(crate) fn into_values(self, caller: Option<&mut FrameState>) -> Result<Vec<Value>> {
+        match self {
+            Self::Owned(values) => Ok(values),
+            Self::Stack(count) => {
+                let caller = caller.ok_or_else(|| {
+                    InternalError("Missing caller for stack arguments".to_owned())
+                })?;
+                Ok(caller.stack.drain_values(count)?.collect())
+            }
+        }
+    }
+
+    pub(crate) fn initialize(
+        self,
+        state: &mut FrameState,
+        class: &Class,
+        method: &Method,
+        caller: Option<&mut FrameState>,
+    ) -> Result<()> {
+        match self {
+            Self::Owned(values) => state.reset(class, method, values),
+            Self::Stack(count) => {
+                let caller = caller.ok_or_else(|| {
+                    InternalError("Missing caller for stack arguments".to_owned())
+                })?;
+                state.reset(class, method, caller.stack.drain_values(count)?)
+            }
+        }
+    }
+}
+
+impl Frame {
+    /// Create a metadata-only frame for the specified class and method.
+    ///
+    /// JIT execution uses this frame for stack walking without allocating interpreter locals or an
+    /// operand stack. The thread owns interpreter storage separately.
+    pub fn new(thread: &Weak<Thread>, class: &Arc<Class>, method: &Arc<Method>) -> Self {
+        Frame {
             thread: thread.clone(),
             class: class.clone(),
             method: method.clone(),
             program_counter: AtomicUsize::new(0),
             method_refs: OnceLock::new(),
             field_refs: OnceLock::new(),
-            state: Mutex::new(Some(FrameState {
-                locals: LocalVariables::new(parameters),
-                stack: OperandStack::with_max_size(method.max_stack()),
-            })),
-        })
+        }
+    }
+
+    /// Reuse metadata only while its Arc is unique, so stack-walker snapshots remain stable.
+    pub(crate) fn reset(&mut self, class: &Arc<Class>, method: &Arc<Method>) {
+        if !Arc::ptr_eq(&self.class, class) {
+            self.method_refs.take();
+            self.field_refs.take();
+            self.class = class.clone();
+        }
+        self.method = method.clone();
+        self.program_counter.store(0, Ordering::Relaxed);
     }
 
     /// Get the thread that owns this frame.
@@ -282,14 +355,14 @@ impl Frame {
 
     /// Execute a bounded batch of bytecodes, returning early for method calls or returns.
     ///
-    /// Keep the frame state locked across the batch to amortize locking and trampoline dispatch.
+    /// The interpreter owns mutable state across the batch, including across async handlers.
     /// The program counter remains current for exceptions and stack walking, and the thread's
     /// instruction budget preserves cooperative scheduling across batches and method calls.
-    pub(crate) async fn execute_batch(&self, thread: &Thread) -> Result<ExecutionResult> {
-        let mut state = self.state.lock().await;
-        let state = state.as_mut().ok_or_else(|| {
-            InternalError("Interpreter frame state is not initialized".to_string())
-        })?;
+    pub(crate) async fn execute_batch(
+        &self,
+        thread: &Thread,
+        state: &mut FrameState,
+    ) -> Result<ExecutionResult> {
         let code = self.method.code();
         let FrameState { locals, stack } = state;
 
@@ -340,15 +413,12 @@ impl Frame {
     }
 
     /// Resume this frame after a method call completes successfully.
-    pub(crate) async fn complete_call(
+    pub(crate) fn complete_call(
         &self,
+        state: &mut FrameState,
         value: Option<Value>,
         has_return_type: bool,
     ) -> Result<()> {
-        let mut state = self.state.lock().await;
-        let state = state.as_mut().ok_or_else(|| {
-            InternalError("Interpreter frame state is not initialized".to_string())
-        })?;
         if has_return_type && let Some(value) = value {
             state.stack.push(value)?;
         }
@@ -357,11 +427,11 @@ impl Frame {
     }
 
     /// Deliver an error raised by a callee to this frame.
-    pub(crate) async fn handle_error(&self, error: crate::Error) -> Result<()> {
-        let mut state = self.state.lock().await;
-        let state = state.as_mut().ok_or_else(|| {
-            InternalError("Interpreter frame state is not initialized".to_string())
-        })?;
+    pub(crate) async fn handle_error(
+        &self,
+        state: &mut FrameState,
+        error: crate::Error,
+    ) -> Result<()> {
         Self::handle_error_with_stack(self, &mut state.stack, error).await
     }
 
@@ -397,47 +467,6 @@ impl Frame {
             .checked_add(method.max_stack())
             .and_then(|slots| slots.checked_add(1))
             .ok_or_else(|| StackOverflowError("Java stack slot count overflow".to_string()).into())
-    }
-
-    /// Adjusts the parameters vector to conform to JVM local variable layout rules.
-    ///
-    /// # Overview
-    ///
-    /// According to the JVM specification, `long` and `double` values occupy two consecutive
-    /// local variable slots. This method inserts `Value::Unused` placeholders after
-    /// each `Long` and `Double` value in the parameters vector to ensure proper layout
-    /// in the local variables array. It also ensures the total size matches `max_size` by
-    /// padding with additional `Value::Unused` entries if necessary.
-    ///
-    /// # JVM Specification
-    ///
-    /// The JVM uses indices to 32-bit address for local variables. Local variables that are `long`
-    /// or `double` occupy two consecutive slots due to their 64-bit width. However, this JVM
-    /// implementation is not constrained by the 32-bit limit, so second slot is reserved and should
-    /// not be used for accessing variables.
-    ///
-    /// # Examples
-    ///
-    /// ```text
-    /// // Before adjustment: [Int(1), Long(2), Float(3.0)]
-    /// // After adjustment:  [Int(1), Long(2), Unused, Float(3.0)]
-    /// ```
-    ///
-    /// # References
-    ///
-    /// - [JVMS §2.6.1](https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-2.html#jvms-2.6.1)
-    fn adjust_parameters(parameters: &mut Vec<Value>, max_size: usize) {
-        for index in (0..parameters.len()).rev() {
-            if matches!(
-                parameters.get(index),
-                Some(Value::Long(_) | Value::Double(_))
-            ) {
-                parameters.insert(index + 1, Value::Unused);
-            }
-        }
-        if parameters.len() < max_size {
-            parameters.resize(max_size, Value::Unused);
-        }
     }
 
     /// Debug the execution of an instruction in this frame
@@ -889,7 +918,7 @@ mod tests {
 
     fn batch_test_frame(
         code: impl FnOnce(u16) -> Vec<Instruction>,
-    ) -> Result<(Arc<Thread>, Frame)> {
+    ) -> Result<(Arc<Thread>, Frame, FrameState)> {
         let mut constant_pool = ConstantPool::default();
         let this_class = constant_pool.add_class("BatchTest")?;
         let name_index = constant_pool.add_utf8("test")?;
@@ -918,18 +947,54 @@ mod tests {
         )?;
         let thread = Thread::new(&Weak::new(), 1);
         let method = class.try_get_method("test", "(I)I")?;
-        let frame = Frame::with_parameters(
-            &Arc::downgrade(&thread),
+        let frame = Frame::new(&Arc::downgrade(&thread), &class, &method);
+        let mut state = FrameState::default();
+        state.reset(&class, &method, [Value::Int(1_000)])?;
+        Ok((thread, frame, state))
+    }
+
+    #[test]
+    fn test_stack_arguments_fill_reused_wide_locals() -> Result<()> {
+        let (_thread, frame, _) = batch_test_frame(|_| vec![Instruction::Return])?;
+        let mut definition = frame.class().class_file().clone();
+        let definition_method = definition.methods.first_mut().expect("test method");
+        definition_method.descriptor_index = definition.constant_pool.add_utf8("(JD)D")?;
+        for attribute in &mut definition_method.attributes {
+            if let Attribute::Code { max_locals, .. } = attribute {
+                *max_locals = 6;
+            }
+        }
+        let class = Class::from(None, definition)?;
+        let method = class.try_get_method("test", "(JD)D")?;
+        let mut caller = FrameState::default();
+        caller.stack.reset(3);
+        caller.stack.push_int(19)?;
+        caller.stack.push_long(42)?;
+        caller.stack.push_double(2.0)?;
+        let mut destination = FrameState::default();
+        destination.reset(&class, &method, vec![Value::Int(99); 6])?;
+        CallParameters::Stack(2).initialize(
+            &mut destination,
             &class,
             &method,
-            vec![Value::Int(1_000)],
+            Some(&mut caller),
         )?;
-        Ok((thread, frame))
+        assert_eq!(19, caller.stack.pop_int()?);
+        assert!(caller.stack.is_empty());
+        assert_eq!(42, destination.locals.get_long(0)?);
+        assert_eq!(Value::Unused, destination.locals.get(1)?);
+        assert_eq!(Value::Double(2.0), destination.locals.get(2)?);
+        for index in [3, 4, 5] {
+            assert_eq!(Value::Unused, destination.locals.get(index)?);
+        }
+        assert!(destination.locals.get(6).is_err());
+        assert!(destination.stack.is_empty());
+        Ok(())
     }
 
     #[tokio::test]
     async fn test_batch_preserves_locals_stack_and_branches() -> Result<()> {
-        let (thread, frame) = batch_test_frame(|_| {
+        let (thread, frame, mut state) = batch_test_frame(|_| {
             vec![
                 Instruction::Iconst_0,
                 Instruction::Iload_0,
@@ -943,11 +1008,10 @@ mod tests {
         })?;
 
         // The loop must stop at a batch boundary before finishing the method.
-        let mut result = frame.execute_batch(&thread).await?;
+        let mut result = frame.execute_batch(&thread, &mut state).await?;
         assert_eq!(ExecutionResult::Continue, result);
-        assert!(frame.state.try_lock().is_ok());
         for _ in 0..100 {
-            result = frame.execute_batch(&thread).await?;
+            result = frame.execute_batch(&thread, &mut state).await?;
             if result != ExecutionResult::Continue {
                 break;
             }
@@ -959,21 +1023,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_stops_at_return() -> Result<()> {
-        let (thread, frame) =
+        let (thread, frame, mut state) =
             batch_test_frame(|_| vec![Instruction::Iconst_1, Instruction::Ireturn])?;
         assert_eq!(
             ExecutionResult::Return(Some(Value::Int(1))),
-            frame.execute_batch(&thread).await?
+            frame.execute_batch(&thread, &mut state).await?
         );
         assert_eq!(1, frame.program_counter());
-        assert!(frame.state.try_lock().is_ok());
         Ok(())
     }
 
     #[tokio::test]
     async fn test_batches_yield_with_sync_and_ready_async_handlers() -> Result<()> {
         for ready_async in [false, true] {
-            let (thread, frame) = batch_test_frame(|class_index| {
+            let (thread, frame, mut state) = batch_test_frame(|class_index| {
                 if ready_async {
                     // instanceof null uses an async handler that completes without awaiting.
                     vec![
@@ -994,7 +1057,7 @@ mod tests {
                     for _ in 0..64 {
                         assert_eq!(
                             ExecutionResult::Continue,
-                            frame.execute_batch(&thread).await?
+                            frame.execute_batch(&thread, &mut state).await?
                         );
                     }
                     Ok::<(), crate::Error>(())
@@ -1003,11 +1066,10 @@ mod tests {
                 assert!(execution.as_mut().poll(&mut context).is_pending());
             }
 
-            // Cancelling a yielded batch releases its state guard, and the frame can resume.
-            assert!(frame.state.try_lock().is_ok());
+            // Cancelling a yielded batch ends the mutable borrow, and the frame can resume.
             assert_eq!(
                 ExecutionResult::Continue,
-                frame.execute_batch(&thread).await?
+                frame.execute_batch(&thread, &mut state).await?
             );
         }
         Ok(())
@@ -1039,18 +1101,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reused_metadata_resets_pc_and_class_references() -> Result<()> {
+        let (vm, _thread, mut frame) = crate::test::frame().await?;
+        let original_class = frame.class().clone();
+        let original_method = frame.method().clone();
+        let methods = vm.method_ref_cache().for_class(&original_class);
+        let fields = vm.field_ref_cache().for_class(&original_class);
+        assert!(std::ptr::eq(frame.method_refs()?, methods.as_ref()));
+        assert!(std::ptr::eq(frame.field_refs()?, fields.as_ref()));
+        frame.program_counter.store(17, Ordering::Relaxed);
+        frame.reset(&original_class, &original_method);
+        assert_eq!(0, frame.program_counter());
+        assert!(std::ptr::eq(frame.method_refs()?, methods.as_ref()));
+        let mut definition = original_class.class_file().clone();
+        definition.this_class = definition.constant_pool.add_class("OtherFrameClass")?;
+        let other = Class::from(None, definition)?;
+        let method = other.try_get_method("test", "()V")?;
+        frame.reset(&other, &method);
+        assert!(!std::ptr::eq(frame.method_refs()?, methods.as_ref()));
+        assert!(!std::ptr::eq(frame.field_refs()?, fields.as_ref()));
+        assert!(Arc::ptr_eq(frame.method(), &method));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_method_call_equality() -> Result<()> {
         let (_vm, _thread, frame) = crate::test::frame().await?;
         let call = MethodCall {
             class: frame.class().clone(),
             method: frame.method().clone(),
-            parameters: vec![Value::Int(42)],
+            parameters: vec![Value::Int(42)].into(),
             has_return_type: true,
         };
         let same_call = MethodCall {
             class: frame.class().clone(),
             method: frame.method().clone(),
-            parameters: vec![Value::Int(42)],
+            parameters: vec![Value::Int(42)].into(),
             has_return_type: true,
         };
 
@@ -1060,37 +1146,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_parameters_rejects_too_many_local_slots() -> Result<()> {
-        let (_vm, thread, frame) = crate::test::frame().await?;
-        let result = Frame::with_parameters(
-            &Arc::downgrade(&thread),
-            frame.class(),
-            frame.method(),
-            vec![Value::Int(1)],
-        );
+        let (_vm, _thread, frame) = crate::test::frame().await?;
+        let result = FrameState::default().reset(frame.class(), frame.method(), [Value::Int(1)]);
 
         assert!(matches!(result, Err(InternalError(message)) if message ==
             "Method parameters require 1 local-variable slots, but Test.test()V declares 0"));
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_metadata_frame_does_not_allocate_interpreter_state() -> Result<()> {
-        let (_vm, _thread, frame) = crate::test::frame().await?;
-        assert!(frame.state.lock().await.is_none());
-        Ok(())
-    }
-
     #[test]
     fn test_adjust_parameters() {
-        let mut parameters = vec![
+        let parameters = vec![
             Value::Int(1),
             Value::Long(2),
             Value::Float(3.0),
             Value::Double(4.0),
         ];
-        Frame::adjust_parameters(&mut parameters, 8);
+        let mut locals = LocalVariables::with_max_size(0);
+        assert_eq!(6, locals.reset(parameters, 8));
         assert_eq!(
-            parameters,
+            (0..8)
+                .map(|index| locals.get(index).unwrap())
+                .collect::<Vec<_>>(),
             vec![
                 Value::Int(1),
                 Value::Long(2),

--- a/ristretto_vm/src/frame/resolution_tests.rs
+++ b/ristretto_vm/src/frame/resolution_tests.rs
@@ -110,13 +110,20 @@ async fn dispatch(
             frame.process_async(stack, &instruction).await?
         }
     };
-    let ExecutionResult::Call(call) = result else {
+    let ExecutionResult::Call(mut call) = result else {
         panic!("expected method call");
     };
+    if sync {
+        let CallParameters::Stack(count) = call.parameters else {
+            panic!("cached call must defer argument transfer");
+        };
+        assert_eq!(stack.len(), count);
+        call.parameters = stack.drain_values(count)?.collect::<Vec<_>>().into();
+    }
     assert!(stack.is_empty());
     assert!(call.has_return_type);
     assert_eq!(
-        call.parameters[call.parameters.len() - 2..],
+        call.parameters.as_slice(None)?[call.parameters.as_slice(None)?.len() - 2..],
         [Value::Long(17), Value::Double(2.0)]
     );
     Ok(call)
@@ -150,7 +157,7 @@ async fn caller_identity_shared_records_and_invocation_kind() -> Result<()> {
             )
             .await?;
             assert!(Arc::ptr_eq(&call.class, expected));
-            assert_eq!(call.parameters.len(), 2);
+            assert_eq!(call.parameters.as_slice(None)?.len(), 2);
         }
         // Static resolution cannot validate the same CP index for non-static bytecodes.
         for kind in [
@@ -261,7 +268,7 @@ async fn interface_default_override_and_rejected_targets() -> Result<()> {
             )
             .await?;
             assert!(Arc::ptr_eq(&call.class, expected));
-            assert_eq!(call.parameters.len(), 3);
+            assert_eq!(call.parameters.as_slice(None)?.len(), 3);
         }
     }
     let parent_only = target("ParentOnly", None, false)?;

--- a/ristretto_vm/src/instruction/invoke.rs
+++ b/ristretto_vm/src/instruction/invoke.rs
@@ -3,7 +3,7 @@
 use crate::Error::InternalError;
 use crate::JavaError::NullPointerException;
 use crate::Result;
-use crate::frame::{ExecutionResult, Frame, MethodCall};
+use crate::frame::{CallParameters, ExecutionResult, Frame, MethodCall};
 use crate::method_ref_cache::InvokeKind;
 use crate::operand_stack::OperandStack;
 use ristretto_classloader::{Class, Reference, Value};
@@ -73,7 +73,7 @@ pub(crate) fn try_invoke(
     Ok(Some(ExecutionResult::Call(MethodCall {
         class,
         method,
-        parameters: stack.drain_last(resolution.param_count + receiver_count),
+        parameters: CallParameters::Stack(resolution.param_count + receiver_count),
         has_return_type: resolution.has_return_type,
     })))
 }

--- a/ristretto_vm/src/instruction/invokeinterface.rs
+++ b/ristretto_vm/src/instruction/invokeinterface.rs
@@ -44,7 +44,7 @@ pub(crate) async fn invokeinterface(
         return Ok(ExecutionResult::Call(MethodCall {
             class: target.class.clone(),
             method: target.method.clone(),
-            parameters,
+            parameters: parameters.into(),
             has_return_type: resolution.has_return_type,
         }));
     }
@@ -108,7 +108,7 @@ pub(crate) async fn invokeinterface(
     Ok(ExecutionResult::Call(MethodCall {
         class: resolved_class,
         method: resolved_method,
-        parameters,
+        parameters: parameters.into(),
         has_return_type: resolution.has_return_type,
     }))
 }

--- a/ristretto_vm/src/instruction/invokespecial.rs
+++ b/ristretto_vm/src/instruction/invokespecial.rs
@@ -25,7 +25,7 @@ pub(crate) async fn invokespecial(
     Ok(ExecutionResult::Call(MethodCall {
         class: resolution.declaring_class.clone(),
         method: resolution.method.clone(),
-        parameters,
+        parameters: parameters.into(),
         has_return_type: resolution.has_return_type,
     }))
 }

--- a/ristretto_vm/src/instruction/invokestatic.rs
+++ b/ristretto_vm/src/instruction/invokestatic.rs
@@ -29,7 +29,7 @@ pub(crate) async fn invokestatic(
     Ok(ExecutionResult::Call(MethodCall {
         class: resolution.declaring_class.clone(),
         method: resolution.method.clone(),
-        parameters,
+        parameters: parameters.into(),
         has_return_type: resolution.has_return_type,
     }))
 }

--- a/ristretto_vm/src/instruction/invokevirtual.rs
+++ b/ristretto_vm/src/instruction/invokevirtual.rs
@@ -56,7 +56,7 @@ pub(crate) async fn invokevirtual(
             return Ok(ExecutionResult::Call(MethodCall {
                 class: target.class.clone(),
                 method: target.method.clone(),
-                parameters,
+                parameters: parameters.into(),
                 has_return_type: resolution.has_return_type,
             }));
         }
@@ -107,7 +107,7 @@ pub(crate) async fn invokevirtual(
     Ok(ExecutionResult::Call(MethodCall {
         class,
         method,
-        parameters,
+        parameters: parameters.into(),
         has_return_type: resolution.has_return_type,
     }))
 }

--- a/ristretto_vm/src/local_variables.rs
+++ b/ristretto_vm/src/local_variables.rs
@@ -22,6 +22,41 @@ impl LocalVariables {
         Self::new(vec![Value::Unused; max_size])
     }
 
+    /// Refill reusable local storage in JVM slot order, including wide-value placeholders.
+    pub(crate) fn reset(
+        &mut self,
+        parameters: impl IntoIterator<Item = Value>,
+        max_size: usize,
+    ) -> usize {
+        self.locals.clear();
+        // Reusing a large allocation in small recursive frames must not multiply retained
+        // capacity independently of their declared Java stack requirements.
+        if self.locals.capacity() > max_size.saturating_mul(4).max(16) {
+            self.locals.shrink_to(max_size);
+        }
+        self.locals.reserve(max_size);
+        for value in parameters {
+            let wide = matches!(value, Value::Long(_) | Value::Double(_));
+            self.locals.push(value);
+            if wide {
+                self.locals.push(Value::Unused);
+            }
+        }
+        let parameter_slots = self.locals.len();
+        if parameter_slots < max_size {
+            self.locals.resize(max_size, Value::Unused);
+        }
+        parameter_slots
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.locals.clear();
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        self.locals.capacity()
+    }
+
     /// Get a value from the local variables.
     ///
     /// # Errors

--- a/ristretto_vm/src/operand_stack.rs
+++ b/ristretto_vm/src/operand_stack.rs
@@ -12,6 +12,7 @@ use std::fmt::Display;
 #[derive(Debug)]
 pub struct OperandStack {
     stack: Vec<Value>,
+    max_size: usize,
 }
 
 impl OperandStack {
@@ -19,7 +20,43 @@ impl OperandStack {
     pub fn with_max_size(max_size: usize) -> Self {
         OperandStack {
             stack: Vec::with_capacity(max_size),
+            max_size,
         }
+    }
+
+    pub(crate) fn reset(&mut self, max_size: usize) {
+        self.stack.clear();
+        // Reusing a large allocation in small recursive frames must not multiply retained
+        // capacity independently of their declared Java stack requirements.
+        if self.stack.capacity() > max_size.saturating_mul(4).max(16) {
+            self.stack.shrink_to(max_size);
+        }
+        self.stack.reserve(max_size);
+        self.max_size = max_size;
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        self.stack.capacity()
+    }
+
+    /// Borrow call arguments without allocating a temporary argument vector.
+    pub(crate) fn last_values(&self, count: usize) -> Result<&[Value]> {
+        let start = self
+            .stack
+            .len()
+            .checked_sub(count)
+            .ok_or(OperandStackUnderflow)?;
+        self.stack.get(start..).ok_or(OperandStackUnderflow)
+    }
+
+    /// Move call arguments directly into the callee's local slots.
+    pub(crate) fn drain_values(&mut self, count: usize) -> Result<std::vec::Drain<'_, Value>> {
+        let start = self
+            .stack
+            .len()
+            .checked_sub(count)
+            .ok_or(OperandStackUnderflow)?;
+        Ok(self.stack.drain(start..))
     }
 
     /// Drain the last `n` values from the operand stack.
@@ -47,7 +84,7 @@ impl OperandStack {
     /// Push a value onto the operand stack.
     #[inline]
     pub fn push(&mut self, value: Value) -> Result<()> {
-        if self.stack.len() >= self.stack.capacity() {
+        if self.stack.len() >= self.max_size {
             return Err(OperandStackOverflow);
         }
         self.stack.push(value);
@@ -204,6 +241,42 @@ mod tests {
     use crate::operand_stack::OperandStack;
     use ristretto_classloader::Reference;
     use ristretto_gc::GarbageCollector;
+
+    #[test]
+    fn reused_capacity_preserves_declared_limit_and_arguments() -> Result<()> {
+        let mut stack = OperandStack::with_max_size(16);
+        stack.push_long(42)?;
+        let allocation = stack.stack.as_ptr();
+        stack.reset(2);
+        assert!(stack.is_empty());
+        stack.push_int(7)?;
+        stack.push_double(2.0)?;
+        assert!(matches!(stack.push_int(8), Err(OperandStackOverflow)));
+        assert!(matches!(stack.last_values(3), Err(OperandStackUnderflow)));
+        assert!(matches!(stack.drain_values(3), Err(OperandStackUnderflow)));
+        assert_eq!(2, stack.len());
+        assert_eq!(stack.last_values(1)?, &[Value::Double(2.0)]);
+        assert_eq!(stack.drain_values(1)?.next(), Some(Value::Double(2.0)));
+        assert_eq!(stack.pop_int()?, 7);
+        assert_eq!(allocation, stack.stack.as_ptr());
+        stack.reset(0);
+        assert!(matches!(stack.push_int(1), Err(OperandStackOverflow)));
+        Ok(())
+    }
+
+    #[test]
+    fn reuse_does_not_carry_large_buffers_into_small_frames() -> Result<()> {
+        let mut stack = OperandStack::with_max_size(16_384);
+        stack.reset(1);
+        assert!(stack.capacity() <= 16);
+        stack.push_int(42)?;
+        let mut locals = crate::LocalVariables::with_max_size(16_384);
+        locals.reset([Value::Int(7)], 1);
+        assert!(locals.capacity() <= 16);
+        assert_eq!(7, locals.get_int(0)?);
+        assert!(locals.get(1).is_err());
+        Ok(())
+    }
 
     #[test]
     fn test_drain_last() -> Result<()> {

--- a/ristretto_vm/src/thread.rs
+++ b/ristretto_vm/src/thread.rs
@@ -3,7 +3,7 @@ use crate::JavaError::{RuntimeException, StackOverflowError, UnsatisfiedLinkErro
 use crate::Parameters;
 use crate::RustValue;
 use crate::configuration::{DEFAULT_MAX_JAVA_STACK_SIZE, JAVA_STACK_SLOT_SIZE, VerifyMode};
-use crate::frame::{ExecutionResult, MethodCall};
+use crate::frame::{CallParameters, ExecutionResult, FrameState, MethodCall};
 use crate::java_object::JavaObject;
 use crate::jit_runtime_helpers::ThreadRuntime;
 use crate::rust_value::process_values;
@@ -56,6 +56,7 @@ impl Drop for MonitorGuard {
 #[derive(Debug)]
 struct StackEntry {
     frame: Arc<Frame>,
+    state: Option<FrameState>,
     slots: usize,
     has_return_type: bool,
     _monitor: MonitorGuard,
@@ -64,6 +65,9 @@ struct StackEntry {
 #[derive(Debug)]
 struct JavaStack {
     entries: Vec<StackEntry>,
+    free_frames: Vec<Arc<Frame>>,
+    free_states: Vec<FrameState>,
+    pooled_slots: usize,
     used_slots: usize,
     max_slots: usize,
     overflow_reserve_depth: usize,
@@ -74,6 +78,9 @@ impl JavaStack {
         let entry_capacity = max_slots.saturating_add(STACK_OVERFLOW_RESERVE_SLOTS);
         Self {
             entries: Vec::with_capacity(entry_capacity),
+            free_frames: Vec::new(),
+            free_states: Vec::new(),
+            pooled_slots: 0,
             used_slots: 0,
             max_slots,
             overflow_reserve_depth: 0,
@@ -90,6 +97,7 @@ impl JavaStack {
     fn push(
         &mut self,
         frame: Arc<Frame>,
+        state: FrameState,
         has_return_type: bool,
         monitor: MonitorGuard,
     ) -> Result<()> {
@@ -98,6 +106,7 @@ impl JavaStack {
         self.used_slots = used_slots;
         self.entries.push(StackEntry {
             frame,
+            state: Some(state),
             slots,
             has_return_type,
             _monitor: monitor,
@@ -143,6 +152,7 @@ impl JavaStack {
     fn push_jit(&mut self, frame: Arc<Frame>, has_return_type: bool, monitor: MonitorGuard) {
         self.entries.push(StackEntry {
             frame,
+            state: None,
             slots: 0,
             has_return_type,
             _monitor: monitor,
@@ -155,9 +165,44 @@ impl JavaStack {
         Some(entry)
     }
 
-    fn truncate(&mut self, depth: usize) {
-        while self.entries.len() > depth {
-            let _ = self.pop();
+    fn take_frame(
+        &mut self,
+        thread: &Weak<Thread>,
+        class: &Arc<Class>,
+        method: &Arc<Method>,
+    ) -> Arc<Frame> {
+        while let Some(mut frame) = self.free_frames.pop() {
+            if let Some(metadata) = Arc::get_mut(&mut frame) {
+                metadata.reset(class, method);
+                return frame;
+            }
+        }
+        Arc::new(Frame::new(thread, class, method))
+    }
+
+    fn take_state(&mut self) -> FrameState {
+        let state = self.free_states.pop().unwrap_or_default();
+        self.pooled_slots -= state.capacity();
+        state
+    }
+
+    fn recycle(&mut self, frame: Arc<Frame>, state: Option<FrameState>) {
+        let limit = self.max_slots.saturating_add(STACK_OVERFLOW_RESERVE_SLOTS);
+        if let Some(mut state) = state {
+            state.clear();
+            let capacity = state.capacity();
+            if capacity <= limit.saturating_sub(self.pooled_slots) && self.free_states.len() < limit
+            {
+                self.pooled_slots += capacity;
+                self.free_states.push(state);
+            }
+        }
+        // Retained Arc/Weak snapshots must continue to describe the original invocation.
+        if Arc::strong_count(&frame) == 1
+            && Arc::weak_count(&frame) == 0
+            && self.free_frames.len() < limit
+        {
+            self.free_frames.push(frame);
         }
     }
 }
@@ -174,7 +219,30 @@ struct ExecutionBoundary<'a> {
 
 impl Drop for ExecutionBoundary<'_> {
     fn drop(&mut self) {
-        self.thread.stack.write().truncate(self.depth);
+        while self.thread.stack.read().entries.len() > self.depth {
+            let _ = self.thread.pop_frame();
+        }
+    }
+}
+
+/// Mutable interpreter storage is leased without holding a lock across Java execution.
+/// Dropping a suspended future restores the lease before `ExecutionBoundary` unwinds its frames.
+struct ActiveFrame<'a> {
+    thread: &'a Thread,
+    depth: usize,
+    frame: Arc<Frame>,
+    state: FrameState,
+}
+
+impl Drop for ActiveFrame<'_> {
+    fn drop(&mut self) {
+        let mut stack = self.thread.stack.write();
+        if let Some(entry) = stack.entries.get_mut(self.depth)
+            && Arc::ptr_eq(&entry.frame, &self.frame)
+        {
+            debug_assert!(entry.state.is_none());
+            entry.state = Some(std::mem::take(&mut self.state));
+        }
     }
 }
 
@@ -334,7 +402,7 @@ impl Thread {
         let entry = stack
             .entries
             .last()
-            .ok_or(InternalError("No frame".to_string()))?;
+            .ok_or_else(|| InternalError("No frame".to_string()))?;
         Ok(entry.frame.clone())
     }
 
@@ -1094,17 +1162,21 @@ impl Thread {
         let call = MethodCall {
             class: class.clone(),
             method: method.clone(),
-            parameters,
+            parameters: parameters.into(),
             has_return_type: false,
         };
 
-        match self.dispatch_method(call).await? {
+        match self.dispatch_method(call, None).await? {
             DispatchResult::FramePushed => self.run_interpreter(base_depth).await,
             DispatchResult::Completed(value) => Ok(value),
         }
     }
 
-    async fn dispatch_method(&self, call: MethodCall) -> Result<DispatchResult> {
+    async fn dispatch_method(
+        &self,
+        call: MethodCall,
+        caller: Option<&mut FrameState>,
+    ) -> Result<DispatchResult> {
         let MethodCall {
             class,
             method,
@@ -1117,7 +1189,7 @@ impl Thread {
         let vm = self.vm()?;
 
         let sync_monitor = self
-            .acquire_sync_monitor(&class, &method, &parameters)
+            .acquire_sync_monitor(&class, &method, parameters.as_slice(caller.as_deref())?)
             .await?;
         let monitor_guard = MonitorGuard::new(sync_monitor, self.id);
 
@@ -1148,7 +1220,7 @@ impl Thread {
             let Some(thread) = self.thread.upgrade() else {
                 return Err(InternalError("Call stack is not available".to_string()));
             };
-            let parameters = Parameters::new(parameters);
+            let parameters = Parameters::new(parameters.into_values(caller)?);
             let result = rust_method(thread, parameters).await;
             drop(monitor_guard);
             Self::debug_result(&class, &method, &result);
@@ -1158,12 +1230,26 @@ impl Thread {
             let Some(thread) = self.thread.upgrade() else {
                 return Err(InternalError("Call stack is not available".to_string()));
             };
-            let frame = Arc::new(Frame::new(&self.thread, &class, &method));
-            self.stack
-                .write()
-                .push_jit(frame, has_return_type, monitor_guard);
-            let result = jit::execute(&jit_method, &parameters, gc, &vm, &thread, &class);
-            let _ = self.stack.write().pop();
+            {
+                let mut stack = self.stack.write();
+                let frame = stack.take_frame(&self.thread, &class, &method);
+                stack.push_jit(frame, has_return_type, monitor_guard);
+            }
+            let result = jit::execute(
+                &jit_method,
+                parameters.as_slice(caller.as_deref())?,
+                gc,
+                &vm,
+                &thread,
+                &class,
+            );
+            self.pop_frame()?;
+            if let CallParameters::Stack(count) = parameters {
+                let caller = caller.ok_or_else(|| {
+                    InternalError("Missing caller for stack arguments".to_owned())
+                })?;
+                drop(caller.stack.drain_values(count)?);
+            }
             Self::debug_result(&class, &method, &result);
             return result.map(DispatchResult::Completed);
         } else if method.is_native() {
@@ -1174,75 +1260,114 @@ impl Thread {
         }
 
         let frame_slots = Frame::stack_slots_for(&method)?;
-        self.stack
-            .read()
-            .check_capacity(frame_slots, &class, &method)?;
-        let frame = Arc::new(Frame::with_parameters(
-            &self.thread,
-            &class,
-            &method,
-            parameters,
-        )?);
-        self.stack
-            .write()
-            .push(frame, has_return_type, monitor_guard)?;
+        let mut stack = self.stack.write();
+        stack.check_capacity(frame_slots, &class, &method)?;
+        let mut state = stack.take_state();
+        parameters.initialize(&mut state, &class, &method, caller)?;
+        let frame = stack.take_frame(&self.thread, &class, &method);
+        stack.push(frame, state, has_return_type, monitor_guard)?;
         Ok(DispatchResult::FramePushed)
+    }
+
+    fn active_frame(&self) -> Result<ActiveFrame<'_>> {
+        let mut stack = self.stack.write();
+        let depth = stack.entries.len().saturating_sub(1);
+        let entry = stack
+            .entries
+            .last_mut()
+            .ok_or_else(|| InternalError("Interpreter stack unexpectedly empty".to_owned()))?;
+        let state = entry
+            .state
+            .take()
+            .ok_or_else(|| InternalError("Interpreter frame state is already in use".to_owned()))?;
+        Ok(ActiveFrame {
+            thread: self,
+            depth,
+            frame: entry.frame.clone(),
+            state,
+        })
+    }
+
+    fn pop_frame(&self) -> Result<bool> {
+        let mut stack = self.stack.write();
+        let StackEntry {
+            frame,
+            state,
+            has_return_type,
+            _monitor: monitor,
+            ..
+        } = stack
+            .pop()
+            .ok_or_else(|| InternalError("Interpreter stack unexpectedly empty".to_owned()))?;
+        stack.recycle(frame, state);
+        drop(stack);
+        // Monitor release may wake another Java thread; do it outside the stack lock.
+        drop(monitor);
+        Ok(has_return_type)
     }
 
     async fn run_interpreter(&self, base_depth: usize) -> Result<Option<Value>> {
         loop {
-            let frame = {
-                let stack = self.stack.read();
-                let entry = stack.entries.last().ok_or_else(|| {
-                    InternalError("Interpreter stack unexpectedly empty".to_string())
-                })?;
-                entry.frame.clone()
-            };
-
-            match frame.execute_batch(self).await {
-                Ok(ExecutionResult::Continue) => {}
-                Ok(ExecutionResult::Call(call)) => {
-                    let has_return_type = call.has_return_type;
-                    match self.dispatch_method(call).await {
-                        Ok(DispatchResult::FramePushed) => {}
-                        Ok(DispatchResult::Completed(value)) => {
-                            if let Err(error) = frame.complete_call(value, has_return_type).await {
-                                self.propagate_error(base_depth, error, false).await?;
+            let mut active = self.active_frame()?;
+            let result = loop {
+                match active.frame.execute_batch(self, &mut active.state).await {
+                    Ok(ExecutionResult::Continue) => {}
+                    Ok(ExecutionResult::Call(call)) => {
+                        let has_return_type = call.has_return_type;
+                        match self.dispatch_method(call, Some(&mut active.state)).await {
+                            Ok(DispatchResult::FramePushed) => break Ok(None),
+                            Ok(DispatchResult::Completed(value)) => {
+                                if let Err(error) = active.frame.complete_call(
+                                    &mut active.state,
+                                    value,
+                                    has_return_type,
+                                ) {
+                                    break Err((error, false));
+                                }
                             }
-                        }
-                        Err(error) => {
-                            self.propagate_error(base_depth, error, false).await?;
+                            Err(error) => break Err((error, false)),
                         }
                     }
+                    Ok(ExecutionResult::Return(value)) => break Ok(Some(value)),
+                    Ok(ExecutionResult::ContinueAtPosition(_)) => {
+                        return Err(InternalError(
+                            "Frame returned an unprocessed branch result".to_owned(),
+                        ));
+                    }
+                    Err(error) => break Err((error, true)),
                 }
-                Ok(ExecutionResult::Return(value)) => {
-                    let entry = self.stack.write().pop().ok_or_else(|| {
-                        InternalError("Interpreter stack unexpectedly empty".to_string())
-                    })?;
-                    let has_return_type = entry.has_return_type;
-                    Self::debug_result(
-                        entry.frame.class(),
-                        entry.frame.method(),
-                        &Ok(value.clone()),
-                    );
-                    drop(entry);
-
+            };
+            if let Ok(Some(value)) = &result {
+                Self::debug_result(
+                    active.frame.class(),
+                    active.frame.method(),
+                    &Ok(value.clone()),
+                );
+            }
+            if let Err((error, true)) = &result {
+                Self::debug_error(active.frame.class(), active.frame.method(), error);
+            }
+            drop(active);
+            match result {
+                Ok(None) => {}
+                Ok(Some(value)) => {
+                    let has_return_type = self.pop_frame()?;
                     if self.stack.read().entries.len() == base_depth {
                         return Ok(value);
                     }
-
-                    let caller = self.current_frame()?;
-                    if let Err(error) = caller.complete_call(value, has_return_type).await {
+                    let mut caller = self.active_frame()?;
+                    let result =
+                        caller
+                            .frame
+                            .complete_call(&mut caller.state, value, has_return_type);
+                    drop(caller);
+                    if let Err(error) = result {
                         self.propagate_error(base_depth, error, false).await?;
                     }
                 }
-                Ok(ExecutionResult::ContinueAtPosition(_)) => {
-                    return Err(InternalError(
-                        "Frame returned an unprocessed branch result".to_string(),
-                    ));
-                }
-                Err(error) => {
-                    self.propagate_error(base_depth, error, true).await?;
+                Err((error, skip_current)) => {
+                    self.propagate_error(base_depth, error, skip_current)
+                        .await?;
                 }
             }
         }
@@ -1255,28 +1380,22 @@ impl Thread {
         skip_current: bool,
     ) -> Result<()> {
         if skip_current {
-            let entry =
-                self.stack.write().pop().ok_or_else(|| {
-                    InternalError("Interpreter stack unexpectedly empty".to_string())
-                })?;
-            Self::debug_error(entry.frame.class(), entry.frame.method(), &error);
-            drop(entry);
+            self.pop_frame()?;
         }
-
         loop {
             if self.stack.read().entries.len() == base_depth {
                 return Err(error);
             }
-
-            let frame = self.current_frame()?;
-            match frame.handle_error(error).await {
+            let mut active = self.active_frame()?;
+            let result = active.frame.handle_error(&mut active.state, error).await;
+            if let Err(error) = &result {
+                Self::debug_error(active.frame.class(), active.frame.method(), error);
+            }
+            drop(active);
+            match result {
                 Ok(()) => return Ok(()),
                 Err(next_error) => {
-                    let entry = self.stack.write().pop().ok_or_else(|| {
-                        InternalError("Interpreter stack unexpectedly empty".to_string())
-                    })?;
-                    Self::debug_error(entry.frame.class(), entry.frame.method(), &next_error);
-                    drop(entry);
+                    self.pop_frame()?;
                     error = next_error;
                 }
             }
@@ -1799,21 +1918,18 @@ mod tests {
         let (_vm, thread) = interpreted_test_thread().await?;
         let class = recursive_test_class(&thread).await?;
         let method = class.try_get_method("recurse", "(I)I")?;
-        let frame = Frame::with_parameters(
-            &Arc::downgrade(&thread),
-            &class,
-            &method,
-            vec![Value::Int(10)],
-        )?;
+        let frame = Frame::new(&Arc::downgrade(&thread), &class, &method);
+        let mut state = FrameState::default();
+        state.reset(&class, &method, [Value::Int(10)])?;
 
         assert_eq!(
             ExecutionResult::Call(MethodCall {
                 class,
                 method,
-                parameters: vec![Value::Int(9)],
+                parameters: vec![Value::Int(9)].into(),
                 has_return_type: true,
             }),
-            frame.execute_batch(&thread).await?
+            frame.execute_batch(&thread, &mut state).await?
         );
         assert_eq!(5, frame.program_counter());
         Ok(())
@@ -1914,6 +2030,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_frame_pool_preserves_snapshots_and_bounds_retained_storage() -> Result<()> {
+        let (_vm, thread) = interpreted_test_thread().await?;
+        let class = recursive_test_class(&thread).await?;
+        let method = class.try_get_method("recurse", "(I)I")?;
+        let other_method = class.try_get_method("catchArithmetic", "()I")?;
+        let mut pool = JavaStack::new(8);
+        let frame = pool.take_frame(&thread.thread, &class, &method);
+        let pointer = Arc::as_ptr(&frame);
+        let mut state = FrameState::default();
+        state.reset(&class, &method, [Value::Int(99)])?;
+        state.stack.push_int(17)?;
+        let capacity = state.capacity();
+        pool.recycle(frame, Some(state));
+        assert_eq!(capacity, pool.pooled_slots);
+        let mut state = pool.take_state();
+        assert!(state.locals.is_empty());
+        assert!(state.stack.is_empty());
+        state.reset(&class, &method, [Value::Int(2)])?;
+        assert_eq!(2, state.locals.get_int(0)?);
+        assert_eq!(capacity, state.capacity());
+        let frame = pool.take_frame(&thread.thread, &class, &other_method);
+        assert_eq!(pointer, Arc::as_ptr(&frame));
+        assert_eq!(0, frame.program_counter());
+        let observer = frame.clone();
+        pool.recycle(frame, Some(state));
+        assert!(pool.free_frames.is_empty());
+        let frame = pool.take_frame(&thread.thread, &class, &method);
+        assert!(!Arc::ptr_eq(&observer, &frame));
+        assert!(Arc::ptr_eq(observer.method(), &other_method));
+        let weak = Arc::downgrade(&frame);
+        pool.recycle(frame, None);
+        assert!(pool.free_frames.is_empty());
+        assert!(weak.upgrade().is_none());
+        // A historical large method must not leave unbounded buffers in the pool.
+        let oversized = FrameState {
+            locals: crate::LocalVariables::with_max_size(2_048),
+            ..FrameState::default()
+        };
+        pool.recycle(observer, Some(oversized));
+        assert_eq!(capacity, pool.pooled_slots);
+        assert!(pool.pooled_slots <= pool.max_slots + STACK_OVERFLOW_RESERVE_SLOTS);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_execution_restores_leased_state_and_reuses_stack() -> Result<()> {
+        let (_vm, thread) = interpreted_test_thread().await?;
+        let class = recursive_test_class(&thread).await?;
+        let method = class.try_get_method("recurse", "(I)I")?;
+        {
+            let parameters = [Value::Int(4_000)];
+            let mut execution = std::pin::pin!(thread.execute(&class, &method, &parameters));
+            let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+            assert!(execution.as_mut().poll(&mut context).is_pending());
+            let stack = thread.stack.read();
+            assert!(!stack.entries.is_empty());
+            assert!(stack.entries.iter().any(|entry| entry.state.is_none()));
+        }
+        {
+            let stack = thread.stack.read();
+            assert!(stack.entries.is_empty());
+            assert_eq!(0, stack.used_slots);
+            assert!(!stack.free_states.is_empty());
+            assert!(
+                stack
+                    .free_states
+                    .iter()
+                    .all(|state| state.locals.is_empty() && state.stack.is_empty())
+            );
+        }
+        assert_eq!(
+            Some(Value::Int(10)),
+            thread.execute(&class, &method, &[Value::Int(10)]).await?
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_execution_boundary_releases_frame_monitor() -> Result<()> {
         let (_vm, thread, class) = crate::test::class().await?;
         let method = class.try_get_method("test", "()V")?;
@@ -1929,6 +2123,7 @@ mod tests {
             };
             thread.stack.write().push(
                 frame,
+                FrameState::default(),
                 false,
                 MonitorGuard::new(Some(monitor.clone()), thread.id()),
             )?;

--- a/ristretto_vm/tests/compatibility.rs
+++ b/ristretto_vm/tests/compatibility.rs
@@ -1,9 +1,15 @@
 #![cfg_attr(target_family = "wasm", allow(unused_imports, dead_code))]
 #![expect(
     clippy::expect_used,
-    clippy::panic_in_result_fn,
-    clippy::unwrap_in_result,
-    reason = "compatibility harness uses assertions and setup expects in Result-returning tests"
+    reason = "compatibility harness uses fixture setup expects"
+)]
+#![cfg_attr(
+    not(target_family = "wasm"),
+    expect(
+        clippy::panic_in_result_fn,
+        clippy::unwrap_in_result,
+        reason = "compatibility harness uses assertions and setup expects in Result-returning tests"
+    )
 )]
 
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
**MacBook Pro M3**

```
cargo bench --bench compiler

compiler/init/int       time:   [24.310 ms 24.378 ms 24.454 ms]
                        change: [−13.920% −11.929% −9.8948%] (p = 0.00 < 0.05)
                        Performance has improved.
compiler/init/jit       time:   [29.537 ms 29.632 ms 29.735 ms]
                        change: [−6.3075% −5.5641% −4.7863%] (p = 0.00 < 0.05)
                        Performance has improved.

compiler/hello_world/int
                        time:   [3.1297 s 3.1448 s 3.1684 s]
                        change: [−17.812% −17.314% −16.720%] (p = 0.00 < 0.05)
                        Performance has improved.
compiler/hello_world_warm/int
                        time:   [1.3376 s 1.3418 s 1.3474 s]
                        change: [−20.052% −19.484% −18.946%] (p = 0.00 < 0.05)
                        Performance has improved.

compiler/hello_world/jit
                        time:   [3.3581 s 3.3657 s 3.3750 s]
                        change: [−16.031% −15.422% −14.870%] (p = 0.00 < 0.05)
                        Performance has improved.
compiler/hello_world_warm/jit
                        time:   [1.4087 s 1.4104 s 1.4125 s]
                        change: [−18.485% −17.923% −17.517%] (p = 0.00 < 0.05)
                        Performance has improved.
```